### PR TITLE
feat: Implement Phase 4 User Allowed Fences module

### DIFF
--- a/backend/src/main/java/com/tse/core_application/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/tse/core_application/config/WebSecurityConfig.java
@@ -45,6 +45,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/orgs/*/createFence", "/api/orgs/*/updateFence", "/api/orgs/*/getFence", "/api/allFence").permitAll()
                 // Assignment endpoints
                 .antMatchers("/api/orgs/*/assignFenceToEntity", "/api/orgs/*/getAssignedEntityOfFence").permitAll()
+                // User Fences endpoints
+                .antMatchers("/api/orgs/*/getUserFences").permitAll()
                 .antMatchers("/h2-console/**").permitAll()
                 .anyRequest().authenticated();
 

--- a/backend/src/main/java/com/tse/core_application/controller/userfence/UserFenceController.java
+++ b/backend/src/main/java/com/tse/core_application/controller/userfence/UserFenceController.java
@@ -1,0 +1,51 @@
+package com.tse.core_application.controller.userfence;
+
+import com.tse.core_application.dto.userfence.UserFencesResponse;
+import com.tse.core_application.service.userfence.UserFenceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST controller for retrieving effective fences available to users.
+ */
+@RestController
+@RequestMapping("/api/orgs")
+@Tag(name = "User Fences", description = "Endpoints for retrieving effective fences available to users")
+public class UserFenceController {
+
+    private final UserFenceService userFenceService;
+
+    public UserFenceController(UserFenceService userFenceService) {
+        this.userFenceService = userFenceService;
+    }
+
+    @GetMapping("/{orgId}/getUserFences")
+    @Operation(
+            summary = "Get effective fences for a user in an org",
+            description = "Returns the union of all fences available to the user via USER, TEAM, PROJECT, and ORG assignments, " +
+                    "de-duplicated with source attribution and a computed default fence."
+    )
+    public ResponseEntity<UserFencesResponse> getUserFences(
+            @PathVariable("orgId")
+            @Parameter(description = "Organization ID", required = true)
+            Long orgId,
+
+            @RequestParam("accountId")
+            @Parameter(description = "User account ID", required = true)
+            Long accountId,
+
+            @RequestParam(value = "includeInactive", required = false, defaultValue = "false")
+            @Parameter(description = "Whether to include inactive fences (default: false)")
+            Boolean includeInactive
+    ) {
+        UserFencesResponse response = userFenceService.getUserFences(
+                orgId,
+                accountId,
+                includeInactive != null ? includeInactive : false
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/dto/userfence/Counts.java
+++ b/backend/src/main/java/com/tse/core_application/dto/userfence/Counts.java
@@ -1,0 +1,75 @@
+package com.tse.core_application.dto.userfence;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Aggregated counts of fence sources by entity type.
+ */
+public class Counts {
+
+    @JsonProperty("total")
+    private int total;
+
+    @JsonProperty("user")
+    private int user;
+
+    @JsonProperty("team")
+    private int team;
+
+    @JsonProperty("project")
+    private int project;
+
+    @JsonProperty("org")
+    private int org;
+
+    public Counts() {
+    }
+
+    public Counts(int total, int user, int team, int project, int org) {
+        this.total = total;
+        this.user = user;
+        this.team = team;
+        this.project = project;
+        this.org = org;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    public int getUser() {
+        return user;
+    }
+
+    public void setUser(int user) {
+        this.user = user;
+    }
+
+    public int getTeam() {
+        return team;
+    }
+
+    public void setTeam(int team) {
+        this.team = team;
+    }
+
+    public int getProject() {
+        return project;
+    }
+
+    public void setProject(int project) {
+        this.project = project;
+    }
+
+    public int getOrg() {
+        return org;
+    }
+
+    public void setOrg(int org) {
+        this.org = org;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/dto/userfence/EffectiveFenceDto.java
+++ b/backend/src/main/java/com/tse/core_application/dto/userfence/EffectiveFenceDto.java
@@ -1,0 +1,125 @@
+package com.tse.core_application.dto.userfence;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents an effective fence available to a user with all contributing sources.
+ */
+public class EffectiveFenceDto {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("locationKind")
+    private String locationKind;
+
+    @JsonProperty("siteCode")
+    private String siteCode;
+
+    @JsonProperty("tz")
+    private String tz;
+
+    @JsonProperty("centerLat")
+    private Double centerLat;
+
+    @JsonProperty("centerLng")
+    private Double centerLng;
+
+    @JsonProperty("radiusM")
+    private Integer radiusM;
+
+    @JsonProperty("isActive")
+    private Boolean isActive;
+
+    @JsonProperty("sources")
+    private List<SourceRef> sources = new ArrayList<>();
+
+    public EffectiveFenceDto() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLocationKind() {
+        return locationKind;
+    }
+
+    public void setLocationKind(String locationKind) {
+        this.locationKind = locationKind;
+    }
+
+    public String getSiteCode() {
+        return siteCode;
+    }
+
+    public void setSiteCode(String siteCode) {
+        this.siteCode = siteCode;
+    }
+
+    public String getTz() {
+        return tz;
+    }
+
+    public void setTz(String tz) {
+        this.tz = tz;
+    }
+
+    public Double getCenterLat() {
+        return centerLat;
+    }
+
+    public void setCenterLat(Double centerLat) {
+        this.centerLat = centerLat;
+    }
+
+    public Double getCenterLng() {
+        return centerLng;
+    }
+
+    public void setCenterLng(Double centerLng) {
+        this.centerLng = centerLng;
+    }
+
+    public Integer getRadiusM() {
+        return radiusM;
+    }
+
+    public void setRadiusM(Integer radiusM) {
+        this.radiusM = radiusM;
+    }
+
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public List<SourceRef> getSources() {
+        return sources;
+    }
+
+    public void setSources(List<SourceRef> sources) {
+        this.sources = sources;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/dto/userfence/SourceRef.java
+++ b/backend/src/main/java/com/tse/core_application/dto/userfence/SourceRef.java
@@ -1,0 +1,51 @@
+package com.tse.core_application.dto.userfence;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the source of a fence assignment (entity that contributed the fence).
+ */
+public class SourceRef {
+
+    @JsonProperty("entityTypeId")
+    private Integer entityTypeId;
+
+    @JsonProperty("entityId")
+    private Long entityId;
+
+    @JsonProperty("defaultForEntity")
+    private Boolean defaultForEntity;
+
+    public SourceRef() {
+    }
+
+    public SourceRef(Integer entityTypeId, Long entityId, Boolean defaultForEntity) {
+        this.entityTypeId = entityTypeId;
+        this.entityId = entityId;
+        this.defaultForEntity = defaultForEntity;
+    }
+
+    public Integer getEntityTypeId() {
+        return entityTypeId;
+    }
+
+    public void setEntityTypeId(Integer entityTypeId) {
+        this.entityTypeId = entityTypeId;
+    }
+
+    public Long getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(Long entityId) {
+        this.entityId = entityId;
+    }
+
+    public Boolean getDefaultForEntity() {
+        return defaultForEntity;
+    }
+
+    public void setDefaultForEntity(Boolean defaultForEntity) {
+        this.defaultForEntity = defaultForEntity;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/dto/userfence/UserFencesResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/userfence/UserFencesResponse.java
@@ -1,0 +1,70 @@
+package com.tse.core_application.dto.userfence;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Response containing all effective fences for a user in an organization.
+ */
+public class UserFencesResponse {
+
+    @JsonProperty("orgId")
+    private Long orgId;
+
+    @JsonProperty("accountId")
+    private Long accountId;
+
+    @JsonProperty("defaultFenceIdForUser")
+    private Long defaultFenceIdForUser;
+
+    @JsonProperty("fences")
+    private List<EffectiveFenceDto> fences = new ArrayList<>();
+
+    @JsonProperty("counts")
+    private Counts counts;
+
+    public UserFencesResponse() {
+    }
+
+    public Long getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(Long orgId) {
+        this.orgId = orgId;
+    }
+
+    public Long getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(Long accountId) {
+        this.accountId = accountId;
+    }
+
+    public Long getDefaultFenceIdForUser() {
+        return defaultFenceIdForUser;
+    }
+
+    public void setDefaultFenceIdForUser(Long defaultFenceIdForUser) {
+        this.defaultFenceIdForUser = defaultFenceIdForUser;
+    }
+
+    public List<EffectiveFenceDto> getFences() {
+        return fences;
+    }
+
+    public void setFences(List<EffectiveFenceDto> fences) {
+        this.fences = fences;
+    }
+
+    public Counts getCounts() {
+        return counts;
+    }
+
+    public void setCounts(Counts counts) {
+        this.counts = counts;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/repository/assignment/FenceAssignmentRepository.java
+++ b/backend/src/main/java/com/tse/core_application/repository/assignment/FenceAssignmentRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,4 +38,16 @@ public interface FenceAssignmentRepository extends JpaRepository<FenceAssignment
 
     Optional<FenceAssignment> findByOrgIdAndEntityTypeIdAndEntityIdAndIsDefault(
             Long orgId, Integer entityTypeId, Long entityId, Boolean isDefault);
+
+    List<FenceAssignment> findByOrgIdAndEntityTypeIdAndEntityIdIn(
+            Long orgId, Integer entityTypeId, Collection<Long> entityIds);
+
+    @Query("SELECT fa FROM FenceAssignment fa " +
+           "WHERE fa.orgId = :orgId AND fa.entityTypeId IN :typeIds AND fa.entityId IN :entityIds")
+    List<FenceAssignment> findByOrgIdAndEntityTypeIdInAndEntityIdIn(
+            @Param("orgId") Long orgId,
+            @Param("typeIds") Collection<Integer> typeIds,
+            @Param("entityIds") Collection<Long> entityIds);
+
+    List<FenceAssignment> findByOrgIdAndFenceIdIn(Long orgId, Collection<Long> fenceIds);
 }

--- a/backend/src/main/java/com/tse/core_application/repository/fence/GeoFenceRepository.java
+++ b/backend/src/main/java/com/tse/core_application/repository/fence/GeoFenceRepository.java
@@ -5,10 +5,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface GeoFenceRepository extends JpaRepository<GeoFence, Long>, JpaSpecificationExecutor<GeoFence> {
 
     Optional<GeoFence> findByIdAndOrgId(Long id, Long orgId);
+
+    List<GeoFence> findByOrgIdAndIdIn(Long orgId, Collection<Long> ids);
+
+    List<GeoFence> findByOrgIdAndIdInAndIsActiveTrue(Long orgId, Collection<Long> ids);
 }

--- a/backend/src/main/java/com/tse/core_application/service/membership/MembershipProvider.java
+++ b/backend/src/main/java/com/tse/core_application/service/membership/MembershipProvider.java
@@ -1,0 +1,39 @@
+package com.tse.core_application.service.membership;
+
+import java.util.List;
+
+/**
+ * Interface for resolving user memberships across teams and projects.
+ * Used for determining effective fence assignments.
+ */
+public interface MembershipProvider {
+
+    /**
+     * Returns the list of team IDs that the given user belongs to in the specified org.
+     *
+     * @param orgId the organization ID
+     * @param accountId the user account ID
+     * @return list of team IDs (empty if none)
+     */
+    List<Long> listTeamsForUser(long orgId, long accountId);
+
+    /**
+     * Returns the list of project IDs that the given user belongs to in the specified org.
+     *
+     * @param orgId the organization ID
+     * @param accountId the user account ID
+     * @return list of project IDs (empty if none)
+     */
+    List<Long> listProjectsForUser(long orgId, long accountId);
+
+    /**
+     * Checks if the given organization exists.
+     * Default implementation returns true (for demo/skip-org-validation).
+     *
+     * @param orgId the organization ID
+     * @return true if org exists, false otherwise
+     */
+    default boolean orgExists(long orgId) {
+        return true;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/service/membership/impl/NoopMembershipProvider.java
+++ b/backend/src/main/java/com/tse/core_application/service/membership/impl/NoopMembershipProvider.java
@@ -1,0 +1,31 @@
+package com.tse.core_application.service.membership.impl;
+
+import com.tse.core_application.service.membership.MembershipProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * No-operation implementation of MembershipProvider.
+ * Returns empty lists for teams and projects.
+ * Used as default until real directory/membership system is integrated.
+ */
+@Service
+public class NoopMembershipProvider implements MembershipProvider {
+
+    @Override
+    public List<Long> listTeamsForUser(long orgId, long accountId) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Long> listProjectsForUser(long orgId, long accountId) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean orgExists(long orgId) {
+        return true;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/service/userfence/UserFenceService.java
+++ b/backend/src/main/java/com/tse/core_application/service/userfence/UserFenceService.java
@@ -1,0 +1,304 @@
+package com.tse.core_application.service.userfence;
+
+import com.tse.core_application.constants.EntityTypes;
+import com.tse.core_application.dto.userfence.Counts;
+import com.tse.core_application.dto.userfence.EffectiveFenceDto;
+import com.tse.core_application.dto.userfence.SourceRef;
+import com.tse.core_application.dto.userfence.UserFencesResponse;
+import com.tse.core_application.entity.assignment.FenceAssignment;
+import com.tse.core_application.entity.fence.GeoFence;
+import com.tse.core_application.exception.ProblemException;
+import com.tse.core_application.repository.assignment.FenceAssignmentRepository;
+import com.tse.core_application.repository.fence.GeoFenceRepository;
+import com.tse.core_application.service.membership.MembershipProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Service for computing effective fences available to a user.
+ */
+@Service
+public class UserFenceService {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserFenceService.class);
+
+    private final FenceAssignmentRepository assignmentRepository;
+    private final GeoFenceRepository fenceRepository;
+    private final MembershipProvider membershipProvider;
+
+    @Value("${attendance.policy.skip-org-validation:true}")
+    private boolean skipOrgValidation;
+
+    public UserFenceService(FenceAssignmentRepository assignmentRepository,
+                            GeoFenceRepository fenceRepository,
+                            MembershipProvider membershipProvider) {
+        this.assignmentRepository = assignmentRepository;
+        this.fenceRepository = fenceRepository;
+        this.membershipProvider = membershipProvider;
+    }
+
+    public UserFencesResponse getUserFences(long orgId, long accountId, boolean includeInactive) {
+        // Validation
+        if (accountId <= 0) {
+            throw new ProblemException(
+                    HttpStatus.BAD_REQUEST,
+                    "VALIDATION_FAILED",
+                    "Invalid accountId",
+                    "accountId must be positive"
+            );
+        }
+
+        if (!skipOrgValidation && !membershipProvider.orgExists(orgId)) {
+            throw new ProblemException(
+                    HttpStatus.NOT_FOUND,
+                    "ORG_NOT_FOUND",
+                    "Organization not found",
+                    "Organization not found: " + orgId
+            );
+        }
+
+        // 1. Expand memberships
+        List<EntityRef> entities = expandMemberships(orgId, accountId);
+
+        // 2. Collect all assignments
+        List<FenceAssignment> allAssignments = collectAssignments(orgId, entities);
+
+        // 3. Validate cross-org consistency
+        validateNoOrgMismatch(orgId, allAssignments);
+
+        // 4. Group assignments by fenceId
+        Map<Long, List<FenceAssignment>> assignmentsByFence = allAssignments.stream()
+                .collect(Collectors.groupingBy(FenceAssignment::getFenceId));
+
+        // 5. Fetch fences
+        Set<Long> fenceIds = assignmentsByFence.keySet();
+        List<GeoFence> fences = fetchFences(orgId, fenceIds, includeInactive);
+
+        // 6. Build response
+        return buildResponse(orgId, accountId, fences, assignmentsByFence, allAssignments);
+    }
+
+    private List<EntityRef> expandMemberships(long orgId, long accountId) {
+        List<EntityRef> entities = new ArrayList<>();
+
+        // USER
+        entities.add(new EntityRef(EntityTypes.USER, accountId));
+
+        // TEAM
+        List<Long> teamIds = membershipProvider.listTeamsForUser(orgId, accountId);
+        teamIds.forEach(teamId -> entities.add(new EntityRef(EntityTypes.TEAM, teamId)));
+
+        // PROJECT
+        List<Long> projectIds = membershipProvider.listProjectsForUser(orgId, accountId);
+        projectIds.forEach(projectId -> entities.add(new EntityRef(EntityTypes.PROJECT, projectId)));
+
+        // ORG
+        entities.add(new EntityRef(EntityTypes.ORG, orgId));
+
+        logger.debug("Expanded memberships for user {} in org {}: {} entities",
+                accountId, orgId, entities.size());
+
+        return entities;
+    }
+
+    private List<FenceAssignment> collectAssignments(long orgId, List<EntityRef> entities) {
+        List<FenceAssignment> allAssignments = new ArrayList<>();
+
+        for (EntityRef entity : entities) {
+            List<FenceAssignment> assignments = assignmentRepository
+                    .findByOrgIdAndEntityTypeIdAndEntityId(orgId, entity.getEntityTypeId(), entity.getEntityId());
+            allAssignments.addAll(assignments);
+        }
+
+        logger.debug("Collected {} total assignments for org {}", allAssignments.size(), orgId);
+
+        return allAssignments;
+    }
+
+    private void validateNoOrgMismatch(long orgId, List<FenceAssignment> assignments) {
+        for (FenceAssignment assignment : assignments) {
+            if (!Objects.equals(assignment.getOrgId(), orgId)) {
+                throw new ProblemException(
+                        HttpStatus.CONFLICT,
+                        "CROSS_ORG_MISMATCH",
+                        "Cross-organization mismatch detected",
+                        "Assignment " + assignment.getId() + " belongs to different org"
+                );
+            }
+        }
+    }
+
+    private List<GeoFence> fetchFences(long orgId, Set<Long> fenceIds, boolean includeInactive) {
+        if (fenceIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<GeoFence> fences;
+        if (includeInactive) {
+            fences = fenceRepository.findByOrgIdAndIdIn(orgId, fenceIds);
+        } else {
+            fences = fenceRepository.findByOrgIdAndIdInAndIsActiveTrue(orgId, fenceIds);
+        }
+
+        logger.debug("Fetched {} fences for org {} (includeInactive={})",
+                fences.size(), orgId, includeInactive);
+
+        return fences;
+    }
+
+    private UserFencesResponse buildResponse(long orgId,
+                                             long accountId,
+                                             List<GeoFence> fences,
+                                             Map<Long, List<FenceAssignment>> assignmentsByFence,
+                                             List<FenceAssignment> allAssignments) {
+        UserFencesResponse response = new UserFencesResponse();
+        response.setOrgId(orgId);
+        response.setAccountId(accountId);
+
+        List<EffectiveFenceDto> effectiveFences = new ArrayList<>();
+
+        for (GeoFence fence : fences) {
+            List<FenceAssignment> fenceAssignments = assignmentsByFence.get(fence.getId());
+            if (fenceAssignments == null) {
+                continue;
+            }
+
+            EffectiveFenceDto dto = new EffectiveFenceDto();
+            dto.setId(fence.getId());
+            dto.setName(fence.getName());
+            dto.setLocationKind(fence.getLocationKind() != null ? fence.getLocationKind().name() : null);
+            dto.setSiteCode(fence.getSiteCode());
+            dto.setTz(fence.getTz());
+            dto.setCenterLat(fence.getCenterLat());
+            dto.setCenterLng(fence.getCenterLng());
+            dto.setRadiusM(fence.getRadiusM());
+            dto.setIsActive(fence.getIsActive());
+
+            // Build sources
+            List<SourceRef> sources = fenceAssignments.stream()
+                    .map(a -> new SourceRef(a.getEntityTypeId(), a.getEntityId(), a.getIsDefault()))
+                    .collect(Collectors.toList());
+            dto.setSources(sources);
+
+            effectiveFences.add(dto);
+        }
+
+        response.setFences(effectiveFences);
+
+        // Compute default fence
+        Long defaultFenceId = computeDefaultFenceId(accountId, allAssignments, assignmentsByFence.keySet());
+        response.setDefaultFenceIdForUser(defaultFenceId);
+
+        // Compute counts
+        Counts counts = computeCounts(effectiveFences, allAssignments);
+        response.setCounts(counts);
+
+        return response;
+    }
+
+    private Long computeDefaultFenceId(long accountId,
+                                       List<FenceAssignment> allAssignments,
+                                       Set<Long> validFenceIds) {
+        // Priority 1: USER-level default
+        Optional<FenceAssignment> userDefault = allAssignments.stream()
+                .filter(a -> a.getEntityTypeId() == EntityTypes.USER)
+                .filter(a -> a.getEntityId().equals(accountId))
+                .filter(FenceAssignment::getIsDefault)
+                .filter(a -> validFenceIds.contains(a.getFenceId()))
+                .findFirst();
+
+        if (userDefault.isPresent()) {
+            return userDefault.get().getFenceId();
+        }
+
+        // Priority 2: TEAM default (earliest by created_datetime)
+        Optional<FenceAssignment> teamDefault = allAssignments.stream()
+                .filter(a -> a.getEntityTypeId() == EntityTypes.TEAM)
+                .filter(FenceAssignment::getIsDefault)
+                .filter(a -> validFenceIds.contains(a.getFenceId()))
+                .min(Comparator.comparing(FenceAssignment::getCreatedDatetime));
+
+        if (teamDefault.isPresent()) {
+            return teamDefault.get().getFenceId();
+        }
+
+        // Priority 3: PROJECT default (earliest by created_datetime)
+        Optional<FenceAssignment> projectDefault = allAssignments.stream()
+                .filter(a -> a.getEntityTypeId() == EntityTypes.PROJECT)
+                .filter(FenceAssignment::getIsDefault)
+                .filter(a -> validFenceIds.contains(a.getFenceId()))
+                .min(Comparator.comparing(FenceAssignment::getCreatedDatetime));
+
+        if (projectDefault.isPresent()) {
+            return projectDefault.get().getFenceId();
+        }
+
+        // Priority 4: ORG default
+        Optional<FenceAssignment> orgDefault = allAssignments.stream()
+                .filter(a -> a.getEntityTypeId() == EntityTypes.ORG)
+                .filter(FenceAssignment::getIsDefault)
+                .filter(a -> validFenceIds.contains(a.getFenceId()))
+                .findFirst();
+
+        return orgDefault.map(FenceAssignment::getFenceId).orElse(null);
+    }
+
+    private Counts computeCounts(List<EffectiveFenceDto> fences, List<FenceAssignment> allAssignments) {
+        // Count unique fences per entity type
+        Set<Long> userFences = new HashSet<>();
+        Set<Long> teamFences = new HashSet<>();
+        Set<Long> projectFences = new HashSet<>();
+        Set<Long> orgFences = new HashSet<>();
+
+        for (FenceAssignment assignment : allAssignments) {
+            Long fenceId = assignment.getFenceId();
+            int entityTypeId = assignment.getEntityTypeId();
+
+            if (entityTypeId == EntityTypes.USER) {
+                userFences.add(fenceId);
+            } else if (entityTypeId == EntityTypes.TEAM) {
+                teamFences.add(fenceId);
+            } else if (entityTypeId == EntityTypes.PROJECT) {
+                projectFences.add(fenceId);
+            } else if (entityTypeId == EntityTypes.ORG) {
+                orgFences.add(fenceId);
+            }
+        }
+
+        return new Counts(
+                fences.size(),
+                userFences.size(),
+                teamFences.size(),
+                projectFences.size(),
+                orgFences.size()
+        );
+    }
+
+    /**
+     * Internal class for representing entity references.
+     */
+    private static class EntityRef {
+        private final int entityTypeId;
+        private final long entityId;
+
+        EntityRef(int entityTypeId, long entityId) {
+            this.entityTypeId = entityTypeId;
+            this.entityId = entityId;
+        }
+
+        int getEntityTypeId() {
+            return entityTypeId;
+        }
+
+        long getEntityId() {
+            return entityId;
+        }
+    }
+}


### PR DESCRIPTION
Add getUserFences endpoint to retrieve effective fences for a user based on USER, TEAM, PROJECT, and ORG assignments with smart default computation.

Features:
- Membership expansion (USER → TEAM → PROJECT → ORG)
- De-duplication with source attribution
- Default fence computation (precedence: USER > TEAM > PROJECT > ORG)
- Active/inactive filtering
- Cross-org leak prevention
- Problem+JSON error handling
- Swagger/OpenAPI documentation

New components:
- UserFenceController: GET /api/orgs/{orgId}/getUserFences
- UserFenceService: Business logic with membership expansion
- MembershipProvider: Interface for team/project lookups (NoopMembershipProvider stub)
- DTOs: UserFencesResponse, EffectiveFenceDto, SourceRef, Counts

Enhanced repositories:
- FenceAssignmentRepository: Bulk query methods
- GeoFenceRepository: Bulk & active-filter queries

Security: permitAll for getUserFences endpoint (demo mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)