### PR TITLE
feat: Implement Phase 6b CHECK_IN/OUT logic

### DIFF
--- a/backend/src/main/java/com/tse/core_application/controller/attendance/AttendanceController.java
+++ b/backend/src/main/java/com/tse/core_application/controller/attendance/AttendanceController.java
@@ -1,0 +1,70 @@
+package com.tse.core_application.controller.attendance;
+
+import com.tse.core_application.dto.attendance.PunchCreateRequest;
+import com.tse.core_application.dto.attendance.PunchResponse;
+import com.tse.core_application.dto.attendance.TodaySummaryResponse;
+import com.tse.core_application.service.attendance.AttendanceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Phase 6b: REST controller for attendance operations (CHECK_IN/OUT).
+ */
+@RestController
+@RequestMapping("/api/orgs/{orgId}/attendance")
+@Tag(name = "Attendance", description = "Attendance and punch operations")
+public class AttendanceController {
+
+    private static final Logger logger = LoggerFactory.getLogger(AttendanceController.class);
+
+    private final AttendanceService attendanceService;
+
+    public AttendanceController(AttendanceService attendanceService) {
+        this.attendanceService = attendanceService;
+    }
+
+    /**
+     * POST /api/orgs/{orgId}/attendance/punch
+     * Process a punch event (CHECK_IN or CHECK_OUT).
+     */
+    @PostMapping("/punch")
+    @Operation(summary = "Process a punch event", description = "Process CHECK_IN or CHECK_OUT event with geofence validation")
+    public ResponseEntity<PunchResponse> processPunch(
+            @Parameter(description = "Organization ID", required = true)
+            @PathVariable("orgId") Long orgId,
+            @Parameter(description = "Punch request", required = true)
+            @RequestBody PunchCreateRequest request) {
+
+        logger.info("POST /api/orgs/{}/attendance/punch - accountId={}, eventKind={}",
+                orgId, request.getAccountId(), request.getEventKind());
+
+        PunchResponse response = attendanceService.processPunch(orgId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * GET /api/orgs/{orgId}/attendance/today
+     * Get today's summary for an account.
+     */
+    @GetMapping("/today")
+    @Operation(summary = "Get today's attendance summary", description = "Get attendance summary for today including events and rollup")
+    public ResponseEntity<TodaySummaryResponse> getTodaySummary(
+            @Parameter(description = "Organization ID", required = true)
+            @PathVariable("orgId") Long orgId,
+            @Parameter(description = "Account ID", required = true)
+            @RequestParam("accountId") Long accountId) {
+
+        logger.info("GET /api/orgs/{}/attendance/today - accountId={}", orgId, accountId);
+
+        TodaySummaryResponse response = attendanceService.getTodaySummary(orgId, accountId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/dto/attendance/PunchCreateRequest.java
+++ b/backend/src/main/java/com/tse/core_application/dto/attendance/PunchCreateRequest.java
@@ -1,0 +1,100 @@
+package com.tse.core_application.dto.attendance;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Phase 6b: Request body for POST /api/orgs/{orgId}/attendance/punch
+ */
+public class PunchCreateRequest {
+
+    @JsonProperty("accountId")
+    private Long accountId;
+
+    @JsonProperty("eventKind")
+    private String eventKind; // "CHECK_IN", "CHECK_OUT", "BREAK_START", "BREAK_END"
+
+    @JsonProperty("lat")
+    private Double lat;
+
+    @JsonProperty("lon")
+    private Double lon;
+
+    @JsonProperty("accuracyM")
+    private Double accuracyM;
+
+    @JsonProperty("clientLocalTs")
+    private String clientLocalTs; // ISO-8601 timestamp
+
+    @JsonProperty("clientTz")
+    private String clientTz; // e.g., "America/New_York"
+
+    @JsonProperty("idempotencyKey")
+    private String idempotencyKey;
+
+    public PunchCreateRequest() {
+    }
+
+    public Long getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(Long accountId) {
+        this.accountId = accountId;
+    }
+
+    public String getEventKind() {
+        return eventKind;
+    }
+
+    public void setEventKind(String eventKind) {
+        this.eventKind = eventKind;
+    }
+
+    public Double getLat() {
+        return lat;
+    }
+
+    public void setLat(Double lat) {
+        this.lat = lat;
+    }
+
+    public Double getLon() {
+        return lon;
+    }
+
+    public void setLon(Double lon) {
+        this.lon = lon;
+    }
+
+    public Double getAccuracyM() {
+        return accuracyM;
+    }
+
+    public void setAccuracyM(Double accuracyM) {
+        this.accuracyM = accuracyM;
+    }
+
+    public String getClientLocalTs() {
+        return clientLocalTs;
+    }
+
+    public void setClientLocalTs(String clientLocalTs) {
+        this.clientLocalTs = clientLocalTs;
+    }
+
+    public String getClientTz() {
+        return clientTz;
+    }
+
+    public void setClientTz(String clientTz) {
+        this.clientTz = clientTz;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/dto/attendance/PunchResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/attendance/PunchResponse.java
@@ -1,0 +1,135 @@
+package com.tse.core_application.dto.attendance;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * Phase 6b: Response for POST /api/orgs/{orgId}/attendance/punch
+ */
+public class PunchResponse {
+
+    @JsonProperty("eventId")
+    private Long eventId;
+
+    @JsonProperty("accountId")
+    private Long accountId;
+
+    @JsonProperty("eventKind")
+    private String eventKind;
+
+    @JsonProperty("eventSource")
+    private String eventSource;
+
+    @JsonProperty("tsUtc")
+    private String tsUtc; // ISO-8601 timestamp
+
+    @JsonProperty("fenceId")
+    private Long fenceId;
+
+    @JsonProperty("underRange")
+    private Boolean underRange;
+
+    @JsonProperty("success")
+    private Boolean success;
+
+    @JsonProperty("verdict")
+    private String verdict; // "PASS", "WARN", "FAIL"
+
+    @JsonProperty("failReason")
+    private String failReason;
+
+    @JsonProperty("flags")
+    private Map<String, Object> flags;
+
+    public PunchResponse() {
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+
+    public Long getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(Long accountId) {
+        this.accountId = accountId;
+    }
+
+    public String getEventKind() {
+        return eventKind;
+    }
+
+    public void setEventKind(String eventKind) {
+        this.eventKind = eventKind;
+    }
+
+    public String getEventSource() {
+        return eventSource;
+    }
+
+    public void setEventSource(String eventSource) {
+        this.eventSource = eventSource;
+    }
+
+    public String getTsUtc() {
+        return tsUtc;
+    }
+
+    public void setTsUtc(String tsUtc) {
+        this.tsUtc = tsUtc;
+    }
+
+    public Long getFenceId() {
+        return fenceId;
+    }
+
+    public void setFenceId(Long fenceId) {
+        this.fenceId = fenceId;
+    }
+
+    public Boolean getUnderRange() {
+        return underRange;
+    }
+
+    public void setUnderRange(Boolean underRange) {
+        this.underRange = underRange;
+    }
+
+    public Boolean getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(Boolean success) {
+        this.success = success;
+    }
+
+    public String getVerdict() {
+        return verdict;
+    }
+
+    public void setVerdict(String verdict) {
+        this.verdict = verdict;
+    }
+
+    public String getFailReason() {
+        return failReason;
+    }
+
+    public void setFailReason(String failReason) {
+        this.failReason = failReason;
+    }
+
+    public Map<String, Object> getFlags() {
+        return flags;
+    }
+
+    public void setFlags(Map<String, Object> flags) {
+        this.flags = flags;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/dto/attendance/TodaySummaryResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/attendance/TodaySummaryResponse.java
@@ -1,0 +1,162 @@
+package com.tse.core_application.dto.attendance;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Phase 6b: Response for GET /api/orgs/{orgId}/attendance/today
+ */
+public class TodaySummaryResponse {
+
+    @JsonProperty("accountId")
+    private Long accountId;
+
+    @JsonProperty("dateKey")
+    private String dateKey; // YYYY-MM-DD
+
+    @JsonProperty("currentStatus")
+    private String currentStatus; // "CHECKED_OUT", "CHECKED_IN", "ON_BREAK", "NOT_STARTED"
+
+    @JsonProperty("firstInUtc")
+    private String firstInUtc; // ISO-8601 timestamp
+
+    @JsonProperty("lastOutUtc")
+    private String lastOutUtc; // ISO-8601 timestamp
+
+    @JsonProperty("workedSeconds")
+    private Integer workedSeconds;
+
+    @JsonProperty("breakSeconds")
+    private Integer breakSeconds;
+
+    @JsonProperty("events")
+    private List<EventSummary> events;
+
+    public TodaySummaryResponse() {
+    }
+
+    public Long getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(Long accountId) {
+        this.accountId = accountId;
+    }
+
+    public String getDateKey() {
+        return dateKey;
+    }
+
+    public void setDateKey(String dateKey) {
+        this.dateKey = dateKey;
+    }
+
+    public String getCurrentStatus() {
+        return currentStatus;
+    }
+
+    public void setCurrentStatus(String currentStatus) {
+        this.currentStatus = currentStatus;
+    }
+
+    public String getFirstInUtc() {
+        return firstInUtc;
+    }
+
+    public void setFirstInUtc(String firstInUtc) {
+        this.firstInUtc = firstInUtc;
+    }
+
+    public String getLastOutUtc() {
+        return lastOutUtc;
+    }
+
+    public void setLastOutUtc(String lastOutUtc) {
+        this.lastOutUtc = lastOutUtc;
+    }
+
+    public Integer getWorkedSeconds() {
+        return workedSeconds;
+    }
+
+    public void setWorkedSeconds(Integer workedSeconds) {
+        this.workedSeconds = workedSeconds;
+    }
+
+    public Integer getBreakSeconds() {
+        return breakSeconds;
+    }
+
+    public void setBreakSeconds(Integer breakSeconds) {
+        this.breakSeconds = breakSeconds;
+    }
+
+    public List<EventSummary> getEvents() {
+        return events;
+    }
+
+    public void setEvents(List<EventSummary> events) {
+        this.events = events;
+    }
+
+    public static class EventSummary {
+        @JsonProperty("eventId")
+        private Long eventId;
+
+        @JsonProperty("eventKind")
+        private String eventKind;
+
+        @JsonProperty("tsUtc")
+        private String tsUtc;
+
+        @JsonProperty("success")
+        private Boolean success;
+
+        @JsonProperty("verdict")
+        private String verdict;
+
+        public EventSummary() {
+        }
+
+        public Long getEventId() {
+            return eventId;
+        }
+
+        public void setEventId(Long eventId) {
+            this.eventId = eventId;
+        }
+
+        public String getEventKind() {
+            return eventKind;
+        }
+
+        public void setEventKind(String eventKind) {
+            this.eventKind = eventKind;
+        }
+
+        public String getTsUtc() {
+            return tsUtc;
+        }
+
+        public void setTsUtc(String tsUtc) {
+            this.tsUtc = tsUtc;
+        }
+
+        public Boolean getSuccess() {
+            return success;
+        }
+
+        public void setSuccess(Boolean success) {
+            this.success = success;
+        }
+
+        public String getVerdict() {
+            return verdict;
+        }
+
+        public void setVerdict(String verdict) {
+            this.verdict = verdict;
+        }
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/service/attendance/AcceptanceRules.java
+++ b/backend/src/main/java/com/tse/core_application/service/attendance/AcceptanceRules.java
@@ -1,0 +1,264 @@
+package com.tse.core_application.service.attendance;
+
+import com.tse.core_application.constants.attendance.EventKind;
+import com.tse.core_application.constants.attendance.ExceptionCode;
+import com.tse.core_application.entity.policy.AttendancePolicy;
+import com.tse.core_application.entity.attendance.AttendanceEvent;
+import com.tse.core_application.entity.fence.GeoFence;
+import com.tse.core_application.util.GeoMath;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Phase 6b: Business logic for validating CHECK_IN and CHECK_OUT events.
+ */
+@Service
+public class AcceptanceRules {
+
+    private final HolidayProvider holidayProvider;
+    private final OfficePolicyProvider officePolicyProvider;
+
+    public AcceptanceRules(HolidayProvider holidayProvider, OfficePolicyProvider officePolicyProvider) {
+        this.holidayProvider = holidayProvider;
+        this.officePolicyProvider = officePolicyProvider;
+    }
+
+    /**
+     * Validate a CHECK_IN or CHECK_OUT event.
+     *
+     * @param orgId         Organization ID
+     * @param accountId     Account ID
+     * @param eventKind     CHECK_IN or CHECK_OUT
+     * @param lat           Latitude
+     * @param lon           Longitude
+     * @param accuracyM     GPS accuracy in meters
+     * @param policy        Attendance policy
+     * @param fence         Assigned fence (can be null)
+     * @param todayEvents   Events for today (ordered by timestamp)
+     * @return ValidationResult with verdict, fail reason, and flags
+     */
+    public ValidationResult validate(
+            long orgId,
+            long accountId,
+            EventKind eventKind,
+            Double lat,
+            Double lon,
+            Double accuracyM,
+            AttendancePolicy policy,
+            GeoFence fence,
+            List<AttendanceEvent> todayEvents
+    ) {
+        Map<String, Object> flags = new HashMap<>();
+        boolean success;
+        String verdict;
+        String failReason = null;
+
+        // 1. Check accuracy gate
+        if (accuracyM != null && accuracyM > policy.getAccuracyGateM()) {
+            flags.put("low_accuracy", true);
+            if (policy.getIntegrityPosture() == AttendancePolicy.IntegrityPosture.BLOCK) {
+                return new ValidationResult(false, "FAIL", ExceptionCode.LOW_ACCURACY.name(), flags);
+            }
+        }
+
+        // 2. Check geofence if fence is provided
+        boolean underRange = false;
+        if (fence != null && lat != null && lon != null) {
+            double distance = GeoMath.distanceMeters(lat, lon, fence.getCenterLat(), fence.getCenterLng());
+            underRange = distance <= policy.getFenceRadiusM();
+
+            if (!underRange) {
+                flags.put("out_of_fence", true);
+                if (policy.getOutsideFencePolicy() == AttendancePolicy.OutsideFencePolicy.BLOCK) {
+                    return new ValidationResult(false, "FAIL", ExceptionCode.OUTSIDE_FENCE.name(), flags);
+                }
+            }
+        }
+
+        // 3. Check cooldown
+        OffsetDateTime lastEventTime = getLastEventTime(todayEvents);
+        if (lastEventTime != null) {
+            long secondsSinceLastEvent = java.time.Duration.between(lastEventTime, OffsetDateTime.now()).getSeconds();
+            if (secondsSinceLastEvent < policy.getCooldownSeconds()) {
+                return new ValidationResult(false, "FAIL", ExceptionCode.GRACE_EXPIRED.name(), flags);
+            }
+        }
+
+        // 4. Check max punches per day
+        long successfulPunchesToday = countSuccessfulPunches(todayEvents);
+        if (successfulPunchesToday >= policy.getMaxSuccessfulPunchesPerDay()) {
+            return new ValidationResult(false, "FAIL", ExceptionCode.CAP_REACHED.name(), flags);
+        }
+
+        long failedPunchesToday = countFailedPunches(todayEvents);
+        if (failedPunchesToday >= policy.getMaxFailedPunchesPerDay()) {
+            return new ValidationResult(false, "FAIL", ExceptionCode.CAP_REACHED.name(), flags);
+        }
+
+        // 5. Check state transitions for CHECK_IN/OUT
+        if (eventKind == EventKind.CHECK_IN) {
+            if (isCurrentlyCheckedIn(todayEvents)) {
+                return new ValidationResult(false, "FAIL", ExceptionCode.DUP_CHECKIN.name(), flags);
+            }
+        } else if (eventKind == EventKind.CHECK_OUT) {
+            if (!isCurrentlyCheckedIn(todayEvents)) {
+                return new ValidationResult(false, "FAIL", ExceptionCode.MISSING_CHECKIN.name(), flags);
+            }
+        }
+
+        // 6. Check office hours (for CHECK_IN)
+        if (eventKind == EventKind.CHECK_IN) {
+            OffsetDateTime now = OffsetDateTime.now();
+            String tz = officePolicyProvider.getOperationalTimezone(orgId);
+            LocalTime currentTime = now.atZoneSameInstant(ZoneId.of(tz)).toLocalTime();
+            LocalTime officeStart = officePolicyProvider.getOfficeStartTime(orgId);
+            LocalTime officeEnd = officePolicyProvider.getOfficeEndTime(orgId);
+
+            // Calculate allowed window
+            LocalTime earliestCheckin = officeStart.minusMinutes(policy.getAllowCheckinBeforeStartMin());
+            LocalTime latestCheckin = officeStart.plusMinutes(policy.getLateCheckinAfterStartMin());
+
+            if (currentTime.isBefore(earliestCheckin)) {
+                flags.put("too_early", true);
+            } else if (currentTime.isAfter(latestCheckin)) {
+                flags.put("late_checkin", true);
+            }
+        }
+
+        // 7. Check office hours (for CHECK_OUT)
+        if (eventKind == EventKind.CHECK_OUT) {
+            OffsetDateTime now = OffsetDateTime.now();
+            String tz = officePolicyProvider.getOperationalTimezone(orgId);
+            LocalTime currentTime = now.atZoneSameInstant(ZoneId.of(tz)).toLocalTime();
+            LocalTime officeEnd = officePolicyProvider.getOfficeEndTime(orgId);
+
+            LocalTime earliestCheckout = officeEnd.minusMinutes(policy.getAllowCheckoutBeforeEndMin());
+            LocalTime latestCheckout = officeEnd.plusMinutes(policy.getMaxCheckoutAfterEndMin());
+
+            if (currentTime.isBefore(earliestCheckout)) {
+                flags.put("early_checkout", true);
+            } else if (currentTime.isAfter(latestCheckout)) {
+                flags.put("very_late_checkout", true);
+            }
+        }
+
+        // 8. Check max working hours
+        if (eventKind == EventKind.CHECK_OUT) {
+            AttendanceEvent firstCheckin = getFirstCheckinToday(todayEvents);
+            if (firstCheckin != null) {
+                long hoursWorked = java.time.Duration.between(firstCheckin.getTsUtc(), OffsetDateTime.now()).toHours();
+                if (hoursWorked > policy.getMaxWorkingHoursPerDay()) {
+                    flags.put("excessive_hours", true);
+                }
+            }
+        }
+
+        // 9. Check if holiday
+        LocalDate today = LocalDate.now(ZoneId.of(officePolicyProvider.getOperationalTimezone(orgId)));
+        if (holidayProvider.isHoliday(orgId, today)) {
+            flags.put("holiday", true);
+        }
+
+        // 10. Determine final verdict
+        if (flags.containsKey("out_of_fence") || flags.containsKey("low_accuracy") ||
+            flags.containsKey("late_checkin") || flags.containsKey("early_checkout") ||
+            flags.containsKey("excessive_hours") || flags.containsKey("holiday")) {
+            verdict = "WARN";
+            success = true;
+        } else {
+            verdict = "PASS";
+            success = true;
+        }
+
+        return new ValidationResult(success, verdict, failReason, flags);
+    }
+
+    private OffsetDateTime getLastEventTime(List<AttendanceEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return null;
+        }
+        return events.get(events.size() - 1).getTsUtc();
+    }
+
+    private long countSuccessfulPunches(List<AttendanceEvent> events) {
+        if (events == null) {
+            return 0;
+        }
+        return events.stream().filter(AttendanceEvent::getSuccess).count();
+    }
+
+    private long countFailedPunches(List<AttendanceEvent> events) {
+        if (events == null) {
+            return 0;
+        }
+        return events.stream().filter(e -> !e.getSuccess()).count();
+    }
+
+    private boolean isCurrentlyCheckedIn(List<AttendanceEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return false;
+        }
+        // Walk backwards to find the last CHECK_IN or CHECK_OUT
+        for (int i = events.size() - 1; i >= 0; i--) {
+            AttendanceEvent event = events.get(i);
+            if (event.getEventKind() == EventKind.CHECK_IN && event.getSuccess()) {
+                return true;
+            } else if (event.getEventKind() == EventKind.CHECK_OUT && event.getSuccess()) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private AttendanceEvent getFirstCheckinToday(List<AttendanceEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return null;
+        }
+        for (AttendanceEvent event : events) {
+            if (event.getEventKind() == EventKind.CHECK_IN && event.getSuccess()) {
+                return event;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Result of validation.
+     */
+    public static class ValidationResult {
+        private final boolean success;
+        private final String verdict;
+        private final String failReason;
+        private final Map<String, Object> flags;
+
+        public ValidationResult(boolean success, String verdict, String failReason, Map<String, Object> flags) {
+            this.success = success;
+            this.verdict = verdict;
+            this.failReason = failReason;
+            this.flags = flags;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public String getVerdict() {
+            return verdict;
+        }
+
+        public String getFailReason() {
+            return failReason;
+        }
+
+        public Map<String, Object> getFlags() {
+            return flags;
+        }
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/service/attendance/AttendanceService.java
+++ b/backend/src/main/java/com/tse/core_application/service/attendance/AttendanceService.java
@@ -1,0 +1,411 @@
+package com.tse.core_application.service.attendance;
+
+import com.tse.core_application.constants.EntityTypes;
+import com.tse.core_application.constants.attendance.EventAction;
+import com.tse.core_application.constants.attendance.EventKind;
+import com.tse.core_application.constants.attendance.EventSource;
+import com.tse.core_application.constants.attendance.IntegrityVerdict;
+import com.tse.core_application.dto.attendance.PunchCreateRequest;
+import com.tse.core_application.dto.attendance.PunchResponse;
+import com.tse.core_application.dto.attendance.TodaySummaryResponse;
+import com.tse.core_application.entity.assignment.FenceAssignment;
+import com.tse.core_application.entity.attendance.AttendanceDay;
+import com.tse.core_application.entity.attendance.AttendanceEvent;
+import com.tse.core_application.entity.fence.GeoFence;
+import com.tse.core_application.entity.policy.AttendancePolicy;
+import com.tse.core_application.exception.ProblemException;
+import com.tse.core_application.repository.assignment.FenceAssignmentRepository;
+import com.tse.core_application.repository.attendance.AttendanceDayRepository;
+import com.tse.core_application.repository.attendance.AttendanceEventRepository;
+import com.tse.core_application.repository.fence.GeoFenceRepository;
+import com.tse.core_application.repository.policy.AttendancePolicyRepository;
+import com.tse.core_application.service.membership.MembershipProvider;
+import com.tse.core_application.service.policy.PolicyGate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Phase 6b: Orchestration service for attendance operations.
+ */
+@Service
+public class AttendanceService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AttendanceService.class);
+
+    private final AttendanceEventRepository eventRepository;
+    private final AttendanceDayRepository dayRepository;
+    private final AttendancePolicyRepository policyRepository;
+    private final FenceAssignmentRepository assignmentRepository;
+    private final GeoFenceRepository fenceRepository;
+    private final MembershipProvider membershipProvider;
+    private final PolicyGate policyGate;
+    private final AcceptanceRules acceptanceRules;
+    private final DayRollupService dayRollupService;
+    private final OfficePolicyProvider officePolicyProvider;
+
+    public AttendanceService(
+            AttendanceEventRepository eventRepository,
+            AttendanceDayRepository dayRepository,
+            AttendancePolicyRepository policyRepository,
+            FenceAssignmentRepository assignmentRepository,
+            GeoFenceRepository fenceRepository,
+            MembershipProvider membershipProvider,
+            PolicyGate policyGate,
+            AcceptanceRules acceptanceRules,
+            DayRollupService dayRollupService,
+            OfficePolicyProvider officePolicyProvider) {
+        this.eventRepository = eventRepository;
+        this.dayRepository = dayRepository;
+        this.policyRepository = policyRepository;
+        this.assignmentRepository = assignmentRepository;
+        this.fenceRepository = fenceRepository;
+        this.membershipProvider = membershipProvider;
+        this.policyGate = policyGate;
+        this.acceptanceRules = acceptanceRules;
+        this.dayRollupService = dayRollupService;
+        this.officePolicyProvider = officePolicyProvider;
+    }
+
+    /**
+     * Process a punch event (CHECK_IN or CHECK_OUT).
+     */
+    @Transactional
+    public PunchResponse processPunch(long orgId, PunchCreateRequest request) {
+        // 1. Validate policy is active
+        policyGate.assertPolicyActive(orgId);
+
+        // 2. Validate request
+        validatePunchRequest(request);
+
+        // 3. Get attendance policy
+        AttendancePolicy policy = policyRepository.findByOrgId(orgId)
+                .orElseThrow(() -> new ProblemException(
+                        HttpStatus.NOT_FOUND,
+                        "POLICY_NOT_FOUND",
+                        "Attendance policy not found",
+                        "No attendance policy found for org: " + orgId
+                ));
+
+        // 4. Parse event kind
+        EventKind eventKind;
+        try {
+            eventKind = EventKind.valueOf(request.getEventKind());
+        } catch (IllegalArgumentException e) {
+            throw new ProblemException(
+                    HttpStatus.BAD_REQUEST,
+                    "INVALID_EVENT_KIND",
+                    "Invalid event kind",
+                    "Event kind must be CHECK_IN or CHECK_OUT"
+            );
+        }
+
+        // 5. Get assigned fence for user
+        GeoFence fence = getDefaultFenceForUser(orgId, request.getAccountId());
+
+        // 6. Get today's events for validation
+        LocalDate dateKey = dayRollupService.getDateKey(orgId, OffsetDateTime.now());
+        String tz = officePolicyProvider.getOperationalTimezone(orgId);
+        OffsetDateTime dayStart = dateKey.atStartOfDay(ZoneId.of(tz)).toOffsetDateTime();
+        OffsetDateTime dayEnd = dateKey.plusDays(1).atStartOfDay(ZoneId.of(tz)).toOffsetDateTime();
+
+        List<AttendanceEvent> todayEvents = eventRepository.findByOrgIdAndAccountIdAndTsUtcBetweenOrderByTsUtcAsc(
+                orgId, request.getAccountId(), dayStart, dayEnd
+        );
+
+        // 7. Check idempotency
+        if (request.getIdempotencyKey() != null) {
+            Optional<AttendanceEvent> existing = todayEvents.stream()
+                    .filter(e -> request.getIdempotencyKey().equals(e.getIdempotencyKey()))
+                    .findFirst();
+            if (existing.isPresent()) {
+                return mapToResponse(existing.get());
+            }
+        }
+
+        // 8. Validate using AcceptanceRules
+        AcceptanceRules.ValidationResult validation = acceptanceRules.validate(
+                orgId,
+                request.getAccountId(),
+                eventKind,
+                request.getLat(),
+                request.getLon(),
+                request.getAccuracyM(),
+                policy,
+                fence,
+                todayEvents
+        );
+
+        // 9. Create AttendanceEvent
+        AttendanceEvent event = new AttendanceEvent();
+        event.setOrgId(orgId);
+        event.setAccountId(request.getAccountId());
+        event.setEventKind(eventKind);
+        event.setEventSource(EventSource.GEOFENCE);
+        event.setEventAction(EventAction.MANUAL);
+        event.setTsUtc(OffsetDateTime.now());
+
+        if (request.getClientLocalTs() != null) {
+            event.setClientLocalTs(OffsetDateTime.parse(request.getClientLocalTs()));
+        }
+        event.setClientTz(request.getClientTz());
+
+        if (fence != null) {
+            event.setFenceId(fence.getId());
+        }
+        event.setLat(request.getLat());
+        event.setLon(request.getLon());
+        event.setAccuracyM(request.getAccuracyM());
+
+        // Determine under_range
+        boolean underRange = false;
+        if (fence != null && request.getLat() != null && request.getLon() != null) {
+            double distance = com.tse.core_application.util.GeoMath.distanceMeters(
+                    request.getLat(), request.getLon(),
+                    fence.getCenterLat(), fence.getCenterLng()
+            );
+            underRange = distance <= policy.getFenceRadiusM();
+        }
+        event.setUnderRange(underRange);
+
+        event.setSuccess(validation.isSuccess());
+        event.setVerdict(IntegrityVerdict.valueOf(validation.getVerdict()));
+        event.setFailReason(validation.getFailReason());
+        event.setFlags(validation.getFlags());
+        event.setIdempotencyKey(request.getIdempotencyKey());
+
+        // 10. Save event
+        AttendanceEvent savedEvent = eventRepository.save(event);
+
+        // 11. Update day rollup
+        List<AttendanceEvent> updatedEvents = new ArrayList<>(todayEvents);
+        updatedEvents.add(savedEvent);
+        dayRollupService.updateDayRollup(orgId, request.getAccountId(), dateKey, updatedEvents);
+
+        // 12. Return response
+        return mapToResponse(savedEvent);
+    }
+
+    /**
+     * Get today's summary for an account.
+     */
+    @Transactional(readOnly = true)
+    public TodaySummaryResponse getTodaySummary(long orgId, long accountId) {
+        LocalDate dateKey = dayRollupService.getDateKey(orgId, OffsetDateTime.now());
+        String tz = officePolicyProvider.getOperationalTimezone(orgId);
+
+        OffsetDateTime dayStart = dateKey.atStartOfDay(ZoneId.of(tz)).toOffsetDateTime();
+        OffsetDateTime dayEnd = dateKey.plusDays(1).atStartOfDay(ZoneId.of(tz)).toOffsetDateTime();
+
+        List<AttendanceEvent> todayEvents = eventRepository.findByOrgIdAndAccountIdAndTsUtcBetweenOrderByTsUtcAsc(
+                orgId, accountId, dayStart, dayEnd
+        );
+
+        Optional<AttendanceDay> dayOpt = dayRepository.findByOrgIdAndAccountIdAndDateKey(orgId, accountId, dateKey);
+
+        TodaySummaryResponse response = new TodaySummaryResponse();
+        response.setAccountId(accountId);
+        response.setDateKey(dateKey.toString());
+
+        if (dayOpt.isPresent()) {
+            AttendanceDay day = dayOpt.get();
+            response.setFirstInUtc(day.getFirstInUtc() != null ? day.getFirstInUtc().toString() : null);
+            response.setLastOutUtc(day.getLastOutUtc() != null ? day.getLastOutUtc().toString() : null);
+            response.setWorkedSeconds(day.getWorkedSeconds());
+            response.setBreakSeconds(day.getBreakSeconds());
+        } else {
+            response.setWorkedSeconds(0);
+            response.setBreakSeconds(0);
+        }
+
+        // Determine current status
+        String currentStatus = determineCurrentStatus(todayEvents);
+        response.setCurrentStatus(currentStatus);
+
+        // Map events
+        List<TodaySummaryResponse.EventSummary> eventSummaries = todayEvents.stream()
+                .map(this::mapToEventSummary)
+                .collect(Collectors.toList());
+        response.setEvents(eventSummaries);
+
+        return response;
+    }
+
+    private void validatePunchRequest(PunchCreateRequest request) {
+        if (request.getAccountId() == null || request.getAccountId() <= 0) {
+            throw new ProblemException(
+                    HttpStatus.BAD_REQUEST,
+                    "VALIDATION_FAILED",
+                    "Invalid accountId",
+                    "accountId is required and must be positive"
+            );
+        }
+
+        if (request.getEventKind() == null || request.getEventKind().isEmpty()) {
+            throw new ProblemException(
+                    HttpStatus.BAD_REQUEST,
+                    "VALIDATION_FAILED",
+                    "Invalid eventKind",
+                    "eventKind is required"
+            );
+        }
+
+        if (request.getLat() == null || request.getLon() == null) {
+            throw new ProblemException(
+                    HttpStatus.BAD_REQUEST,
+                    "VALIDATION_FAILED",
+                    "Invalid location",
+                    "lat and lon are required"
+            );
+        }
+    }
+
+    private GeoFence getDefaultFenceForUser(long orgId, long accountId) {
+        // Expand memberships
+        Set<EntityRef> entities = expandMemberships(orgId, accountId);
+
+        // Get assignments for all entities
+        List<Integer> entityTypeIds = entities.stream()
+                .map(e -> e.entityTypeId)
+                .distinct()
+                .collect(Collectors.toList());
+        List<Long> entityIds = entities.stream()
+                .map(e -> e.entityId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        List<FenceAssignment> assignments = assignmentRepository
+                .findByOrgIdAndEntityTypeIdInAndEntityIdIn(orgId, entityTypeIds, entityIds);
+
+        if (assignments.isEmpty()) {
+            return null;
+        }
+
+        // Compute default fence with precedence: USER > TEAM > PROJECT > ORG
+        FenceAssignment defaultAssignment = assignments.stream()
+                .min(Comparator
+                        .comparingInt((FenceAssignment a) -> precedence(a.getEntityTypeId()))
+                        .thenComparing(FenceAssignment::getCreatedDatetime))
+                .orElse(null);
+
+        if (defaultAssignment == null) {
+            return null;
+        }
+
+        return fenceRepository.findById(defaultAssignment.getFenceId()).orElse(null);
+    }
+
+    private Set<EntityRef> expandMemberships(long orgId, long accountId) {
+        Set<EntityRef> entities = new HashSet<>();
+
+        // Add USER entity
+        entities.add(new EntityRef(EntityTypes.USER, accountId));
+
+        // Add TEAMs
+        List<Long> teamIds = membershipProvider.listTeamsForUser(orgId, accountId);
+        for (Long teamId : teamIds) {
+            entities.add(new EntityRef(EntityTypes.TEAM, teamId));
+        }
+
+        // Add PROJECTs
+        List<Long> projectIds = membershipProvider.listProjectsForUser(orgId, accountId);
+        for (Long projectId : projectIds) {
+            entities.add(new EntityRef(EntityTypes.PROJECT, projectId));
+        }
+
+        // Add ORG entity
+        entities.add(new EntityRef(EntityTypes.ORG, orgId));
+
+        return entities;
+    }
+
+    private int precedence(int entityTypeId) {
+        if (entityTypeId == EntityTypes.USER) return 1;
+        if (entityTypeId == EntityTypes.TEAM) return 2;
+        if (entityTypeId == EntityTypes.PROJECT) return 3;
+        if (entityTypeId == EntityTypes.ORG) return 4;
+        return 99;
+    }
+
+    private String determineCurrentStatus(List<AttendanceEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return "NOT_STARTED";
+        }
+
+        // Walk backwards to find the last successful event
+        for (int i = events.size() - 1; i >= 0; i--) {
+            AttendanceEvent event = events.get(i);
+            if (!event.getSuccess()) {
+                continue;
+            }
+
+            if (event.getEventKind() == EventKind.CHECK_IN) {
+                return "CHECKED_IN";
+            } else if (event.getEventKind() == EventKind.CHECK_OUT) {
+                return "CHECKED_OUT";
+            } else if (event.getEventKind() == EventKind.BREAK_START) {
+                return "ON_BREAK";
+            } else if (event.getEventKind() == EventKind.BREAK_END) {
+                return "CHECKED_IN";
+            }
+        }
+
+        return "NOT_STARTED";
+    }
+
+    private PunchResponse mapToResponse(AttendanceEvent event) {
+        PunchResponse response = new PunchResponse();
+        response.setEventId(event.getId());
+        response.setAccountId(event.getAccountId());
+        response.setEventKind(event.getEventKind().name());
+        response.setEventSource(event.getEventSource().name());
+        response.setTsUtc(event.getTsUtc().toString());
+        response.setFenceId(event.getFenceId());
+        response.setUnderRange(event.getUnderRange());
+        response.setSuccess(event.getSuccess());
+        response.setVerdict(event.getVerdict().name());
+        response.setFailReason(event.getFailReason());
+        response.setFlags(event.getFlags());
+        return response;
+    }
+
+    private TodaySummaryResponse.EventSummary mapToEventSummary(AttendanceEvent event) {
+        TodaySummaryResponse.EventSummary summary = new TodaySummaryResponse.EventSummary();
+        summary.setEventId(event.getId());
+        summary.setEventKind(event.getEventKind().name());
+        summary.setTsUtc(event.getTsUtc().toString());
+        summary.setSuccess(event.getSuccess());
+        summary.setVerdict(event.getVerdict().name());
+        return summary;
+    }
+
+    private static class EntityRef {
+        final int entityTypeId;
+        final long entityId;
+
+        EntityRef(int entityTypeId, long entityId) {
+            this.entityTypeId = entityTypeId;
+            this.entityId = entityId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            EntityRef entityRef = (EntityRef) o;
+            return entityTypeId == entityRef.entityTypeId && entityId == entityRef.entityId;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(entityTypeId, entityId);
+        }
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/service/attendance/DayRollupService.java
+++ b/backend/src/main/java/com/tse/core_application/service/attendance/DayRollupService.java
@@ -1,0 +1,164 @@
+package com.tse.core_application.service.attendance;
+
+import com.tse.core_application.constants.attendance.AttendanceStatus;
+import com.tse.core_application.constants.attendance.EventKind;
+import com.tse.core_application.entity.attendance.AttendanceDay;
+import com.tse.core_application.entity.attendance.AttendanceEvent;
+import com.tse.core_application.repository.attendance.AttendanceDayRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Phase 6b: Service for computing and updating attendance_day rollups.
+ */
+@Service
+public class DayRollupService {
+
+    private final AttendanceDayRepository dayRepository;
+    private final OfficePolicyProvider officePolicyProvider;
+
+    public DayRollupService(AttendanceDayRepository dayRepository, OfficePolicyProvider officePolicyProvider) {
+        this.dayRepository = dayRepository;
+        this.officePolicyProvider = officePolicyProvider;
+    }
+
+    /**
+     * Update the attendance_day rollup for a specific date.
+     *
+     * @param orgId     Organization ID
+     * @param accountId Account ID
+     * @param dateKey   Date (in operational timezone)
+     * @param events    All events for this date (ordered by timestamp)
+     */
+    @Transactional
+    public void updateDayRollup(long orgId, long accountId, LocalDate dateKey, List<AttendanceEvent> events) {
+        Optional<AttendanceDay> existingOpt = dayRepository.findByOrgIdAndAccountIdAndDateKey(orgId, accountId, dateKey);
+
+        AttendanceDay day;
+        if (existingOpt.isPresent()) {
+            day = existingOpt.get();
+        } else {
+            day = new AttendanceDay();
+            day.setOrgId(orgId);
+            day.setAccountId(accountId);
+            day.setDateKey(dateKey);
+            day.setWorkedSeconds(0);
+            day.setBreakSeconds(0);
+            day.setStatus(AttendanceStatus.ABSENT);
+            day.setAnomalies(new HashMap<>());
+        }
+
+        // Compute rollup from events
+        computeRollup(day, events);
+
+        dayRepository.save(day);
+    }
+
+    private void computeRollup(AttendanceDay day, List<AttendanceEvent> events) {
+        if (events == null || events.isEmpty()) {
+            day.setStatus(AttendanceStatus.ABSENT);
+            day.setFirstInUtc(null);
+            day.setLastOutUtc(null);
+            day.setWorkedSeconds(0);
+            day.setBreakSeconds(0);
+            return;
+        }
+
+        OffsetDateTime firstIn = null;
+        OffsetDateTime lastOut = null;
+        int workedSeconds = 0;
+        int breakSeconds = 0;
+        Map<String, Object> anomalies = new HashMap<>();
+
+        // State tracking
+        OffsetDateTime currentCheckinTime = null;
+        OffsetDateTime currentBreakStartTime = null;
+
+        for (AttendanceEvent event : events) {
+            if (!event.getSuccess()) {
+                continue; // Skip failed events
+            }
+
+            EventKind kind = event.getEventKind();
+
+            if (kind == EventKind.CHECK_IN) {
+                if (firstIn == null) {
+                    firstIn = event.getTsUtc();
+                }
+                currentCheckinTime = event.getTsUtc();
+
+            } else if (kind == EventKind.CHECK_OUT) {
+                lastOut = event.getTsUtc();
+                if (currentCheckinTime != null) {
+                    long seconds = Duration.between(currentCheckinTime, event.getTsUtc()).getSeconds();
+                    workedSeconds += seconds;
+                    currentCheckinTime = null;
+                } else {
+                    anomalies.put("checkout_without_checkin", true);
+                }
+
+            } else if (kind == EventKind.BREAK_START) {
+                currentBreakStartTime = event.getTsUtc();
+
+            } else if (kind == EventKind.BREAK_END) {
+                if (currentBreakStartTime != null) {
+                    long seconds = Duration.between(currentBreakStartTime, event.getTsUtc()).getSeconds();
+                    breakSeconds += seconds;
+                    currentBreakStartTime = null;
+                } else {
+                    anomalies.put("break_end_without_start", true);
+                }
+            }
+        }
+
+        // Handle incomplete state
+        if (currentCheckinTime != null) {
+            // Still checked in - compute worked time until now
+            long seconds = Duration.between(currentCheckinTime, OffsetDateTime.now()).getSeconds();
+            workedSeconds += seconds;
+            anomalies.put("still_checked_in", true);
+        }
+
+        if (currentBreakStartTime != null) {
+            // Still on break
+            long seconds = Duration.between(currentBreakStartTime, OffsetDateTime.now()).getSeconds();
+            breakSeconds += seconds;
+            anomalies.put("still_on_break", true);
+        }
+
+        day.setFirstInUtc(firstIn);
+        day.setLastOutUtc(lastOut);
+        day.setWorkedSeconds(workedSeconds);
+        day.setBreakSeconds(breakSeconds);
+        day.setAnomalies(anomalies);
+
+        // Determine status
+        if (firstIn == null) {
+            day.setStatus(AttendanceStatus.ABSENT);
+        } else if (anomalies.containsKey("still_checked_in") || anomalies.containsKey("still_on_break")) {
+            day.setStatus(AttendanceStatus.INCOMPLETE);
+        } else if (anomalies.containsKey("checkout_without_checkin") || anomalies.containsKey("break_end_without_start")) {
+            day.setStatus(AttendanceStatus.FLAGGED);
+        } else {
+            day.setStatus(AttendanceStatus.PRESENT);
+        }
+    }
+
+    /**
+     * Get the date key for a given timestamp in the operational timezone.
+     *
+     * @param orgId Organization ID
+     * @param ts    Timestamp
+     * @return Date key (LocalDate in operational timezone)
+     */
+    public LocalDate getDateKey(long orgId, OffsetDateTime ts) {
+        String tz = officePolicyProvider.getOperationalTimezone(orgId);
+        return ts.atZoneSameInstant(ZoneId.of(tz)).toLocalDate();
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/service/attendance/DefaultOfficePolicyProvider.java
+++ b/backend/src/main/java/com/tse/core_application/service/attendance/DefaultOfficePolicyProvider.java
@@ -1,0 +1,27 @@
+package com.tse.core_application.service.attendance;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalTime;
+
+/**
+ * Phase 6b: Stub implementation with default office hours (9 AM - 5 PM UTC).
+ */
+@Component
+public class DefaultOfficePolicyProvider implements OfficePolicyProvider {
+
+    @Override
+    public LocalTime getOfficeStartTime(long orgId) {
+        return LocalTime.of(9, 0); // 9:00 AM
+    }
+
+    @Override
+    public LocalTime getOfficeEndTime(long orgId) {
+        return LocalTime.of(17, 0); // 5:00 PM
+    }
+
+    @Override
+    public String getOperationalTimezone(long orgId) {
+        return "UTC";
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/service/attendance/HolidayProvider.java
+++ b/backend/src/main/java/com/tse/core_application/service/attendance/HolidayProvider.java
@@ -1,0 +1,19 @@
+package com.tse.core_application.service.attendance;
+
+import java.time.LocalDate;
+
+/**
+ * Phase 6b: Interface for checking if a date is a holiday.
+ * Stub implementation for now.
+ */
+public interface HolidayProvider {
+
+    /**
+     * Check if a given date is a holiday for the organization.
+     *
+     * @param orgId Organization ID
+     * @param date  Date to check
+     * @return true if holiday, false otherwise
+     */
+    boolean isHoliday(long orgId, LocalDate date);
+}

--- a/backend/src/main/java/com/tse/core_application/service/attendance/NoopHolidayProvider.java
+++ b/backend/src/main/java/com/tse/core_application/service/attendance/NoopHolidayProvider.java
@@ -1,0 +1,17 @@
+package com.tse.core_application.service.attendance;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+/**
+ * Phase 6b: Stub implementation that always returns false (no holidays).
+ */
+@Component
+public class NoopHolidayProvider implements HolidayProvider {
+
+    @Override
+    public boolean isHoliday(long orgId, LocalDate date) {
+        return false;
+    }
+}

--- a/backend/src/main/java/com/tse/core_application/service/attendance/OfficePolicyProvider.java
+++ b/backend/src/main/java/com/tse/core_application/service/attendance/OfficePolicyProvider.java
@@ -1,0 +1,34 @@
+package com.tse.core_application.service.attendance;
+
+import java.time.LocalTime;
+
+/**
+ * Phase 6b: Interface for retrieving office hours policy.
+ * Stub implementation for now.
+ */
+public interface OfficePolicyProvider {
+
+    /**
+     * Get office start time for the organization.
+     *
+     * @param orgId Organization ID
+     * @return Office start time (local time)
+     */
+    LocalTime getOfficeStartTime(long orgId);
+
+    /**
+     * Get office end time for the organization.
+     *
+     * @param orgId Organization ID
+     * @return Office end time (local time)
+     */
+    LocalTime getOfficeEndTime(long orgId);
+
+    /**
+     * Get operational timezone for the organization.
+     *
+     * @param orgId Organization ID
+     * @return Timezone ID (e.g., "America/New_York")
+     */
+    String getOperationalTimezone(long orgId);
+}


### PR DESCRIPTION
This commit implements the core CHECK_IN and CHECK_OUT attendance functionality:

## DTOs
- PunchCreateRequest: Request body for punch events
- PunchResponse: Response with event details and validation result
- TodaySummaryResponse: Daily attendance summary with events

## Services
- AcceptanceRules: Business logic for validating CHECK_IN/OUT events
  - Accuracy gate validation
  - Geofence validation (distance check)
  - Cooldown enforcement
  - Max punches per day limits
  - State transition validation (prevent duplicate check-ins)
  - Office hours validation (early/late detection)
  - Max working hours check
  - Holiday detection
- DayRollupService: Computes attendance_day rollups from events
  - Calculates worked/break seconds
  - Tracks first_in/last_out timestamps
  - Detects anomalies (still checked in, missing check-in)
  - Determines attendance status
- AttendanceService: Orchestration layer
  - Processes punch events with validation
  - Determines default fence for user
  - Manages idempotency
  - Updates day rollups after each event
  - Provides today's summary

## Providers
- HolidayProvider / NoopHolidayProvider: Holiday detection (stub)
- OfficePolicyProvider / DefaultOfficePolicyProvider: Office hours policy (stub)

## Controller
- AttendanceController: REST endpoints
  - POST /api/orgs/{orgId}/attendance/punch
  - GET /api/orgs/{orgId}/attendance/today

Build: SUCCESS (78 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)