### PR TITLE
feat: Implement Phase 6c BREAK and PUNCHED events

### DIFF
--- a/backend/src/main/java/com/tse/core_application/controller/attendance/AttendanceController.java
+++ b/backend/src/main/java/com/tse/core_application/controller/attendance/AttendanceController.java
@@ -50,6 +50,28 @@ public class AttendanceController {
     }
 
     /**
+     * POST /api/orgs/{orgId}/attendance/punched
+     * Process a PUNCHED event (supervisor-triggered punch).
+     */
+    @PostMapping("/punched")
+    @Operation(summary = "Process a PUNCHED event", description = "Fulfill a punch request with PUNCHED event")
+    public ResponseEntity<PunchResponse> processPunched(
+            @Parameter(description = "Organization ID", required = true)
+            @PathVariable("orgId") Long orgId,
+            @Parameter(description = "Account ID", required = true)
+            @RequestParam("accountId") Long accountId,
+            @Parameter(description = "Punch Request ID", required = true)
+            @RequestParam("punchRequestId") Long punchRequestId) {
+
+        logger.info("POST /api/orgs/{}/attendance/punched - accountId={}, punchRequestId={}",
+                orgId, accountId, punchRequestId);
+
+        PunchResponse response = attendanceService.processPunchedEvent(orgId, accountId, punchRequestId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
      * GET /api/orgs/{orgId}/attendance/today
      * Get today's summary for an account.
      */


### PR DESCRIPTION
This commit extends Phase 6b to support BREAK and PUNCHED event types:

## AcceptanceRules Extensions
- validateBreak(): Validation for BREAK_START and BREAK_END events
  - Checks user has checked in before starting break
  - Prevents duplicate break starts (ALREADY_ON_BREAK)
  - Prevents break end without start (NOT_ON_BREAK)
- validatePunched(): Validation for PUNCHED events
  - Validates PunchRequest is PENDING and within time window
  - Ensures user has checked in before fulfilling punch request
  - Prevents punch while on break
- isCurrentlyOnBreak(): Helper to determine break state

## AttendanceService Extensions
- processPunchedEvent(): Orchestration for PUNCHED events
  - Fetches and validates PunchRequest
  - Validates org ownership
  - Marks PunchRequest as FULFILLED on success
  - Creates PUNCHED event with SUPERVISOR source
  - Links to requester_account_id and punch_request_id
- processPunch() now handles BREAK_START/BREAK_END via existing flow

## AttendanceController
- POST /api/orgs/{orgId}/attendance/punched
  - Accepts accountId and punchRequestId query params
  - Returns PunchResponse with event details

## DayRollupService
- Already handles BREAK events from Phase 6b
  - Tracks break_seconds separately from worked_seconds
  - Detects anomalies (break_end_without_start, still_on_break)

## Event Flow Summary
1. CHECK_IN → User punches in (Phase 6b)
2. BREAK_START → User starts break (Phase 6c)
3. BREAK_END → User ends break (Phase 6c)
4. PUNCHED → Supervisor fulfills pending request (Phase 6c)
5. CHECK_OUT → User punches out (Phase 6b)

Build: SUCCESS (78 source files)
Changes: 3 files modified, 194 insertions (+), 2 deletions (-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)