### PR TITLE
refactor: Add Lombok annotations to all DTO classes

### DIFF
--- a/backend/src/main/java/com/tse/core_application/dto/assignment/AssignFenceRequest.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/AssignFenceRequest.java
@@ -2,7 +2,15 @@ package com.tse.core_application.dto.assignment;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class AssignFenceRequest {
 
     @NotNull
@@ -13,40 +21,4 @@ public class AssignFenceRequest {
     private List<EntityActionItem> remove;
 
     private Long updatedBy;
-
-    public AssignFenceRequest() {
-    }
-
-    // Getters and Setters
-    public Long getFenceId() {
-        return fenceId;
-    }
-
-    public void setFenceId(Long fenceId) {
-        this.fenceId = fenceId;
-    }
-
-    public List<EntityActionItem> getAdd() {
-        return add;
-    }
-
-    public void setAdd(List<EntityActionItem> add) {
-        this.add = add;
-    }
-
-    public List<EntityActionItem> getRemove() {
-        return remove;
-    }
-
-    public void setRemove(List<EntityActionItem> remove) {
-        this.remove = remove;
-    }
-
-    public Long getUpdatedBy() {
-        return updatedBy;
-    }
-
-    public void setUpdatedBy(Long updatedBy) {
-        this.updatedBy = updatedBy;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/assignment/AssignFenceResult.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/AssignFenceResult.java
@@ -4,7 +4,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AssignFenceResult {
     private Long fenceId;
@@ -12,48 +20,4 @@ public class AssignFenceResult {
     private List<EntityResult> results;
     private OffsetDateTime updatedAt;
     private Long updatedBy;
-
-    public AssignFenceResult() {
-    }
-
-    // Getters and Setters
-    public Long getFenceId() {
-        return fenceId;
-    }
-
-    public void setFenceId(Long fenceId) {
-        this.fenceId = fenceId;
-    }
-
-    public AssignmentSummary getSummary() {
-        return summary;
-    }
-
-    public void setSummary(AssignmentSummary summary) {
-        this.summary = summary;
-    }
-
-    public List<EntityResult> getResults() {
-        return results;
-    }
-
-    public void setResults(List<EntityResult> results) {
-        this.results = results;
-    }
-
-    public OffsetDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(OffsetDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public Long getUpdatedBy() {
-        return updatedBy;
-    }
-
-    public void setUpdatedBy(Long updatedBy) {
-        this.updatedBy = updatedBy;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/assignment/AssignedEntitiesResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/AssignedEntitiesResponse.java
@@ -1,47 +1,19 @@
 package com.tse.core_application.dto.assignment;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AssignedEntitiesResponse {
     private Long fenceId;
     private EntityLists assigned;
     private EntityLists unassigned;
     private EntityCounts count;
-
-    public AssignedEntitiesResponse() {
-    }
-
-    // Getters and Setters
-    public Long getFenceId() {
-        return fenceId;
-    }
-
-    public void setFenceId(Long fenceId) {
-        this.fenceId = fenceId;
-    }
-
-    public EntityLists getAssigned() {
-        return assigned;
-    }
-
-    public void setAssigned(EntityLists assigned) {
-        this.assigned = assigned;
-    }
-
-    public EntityLists getUnassigned() {
-        return unassigned;
-    }
-
-    public void setUnassigned(EntityLists unassigned) {
-        this.unassigned = unassigned;
-    }
-
-    public EntityCounts getCount() {
-        return count;
-    }
-
-    public void setCount(EntityCounts count) {
-        this.count = count;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/assignment/AssignedEntity.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/AssignedEntity.java
@@ -3,54 +3,19 @@ package com.tse.core_application.dto.assignment;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AssignedEntity {
     private Long entityId;
     private String name;
     private Boolean defaultForEntity;
     private List<Long> fenceIds;
-
-    public AssignedEntity() {
-    }
-
-    public AssignedEntity(Long entityId, String name, Boolean defaultForEntity, List<Long> fenceIds) {
-        this.entityId = entityId;
-        this.name = name;
-        this.defaultForEntity = defaultForEntity;
-        this.fenceIds = fenceIds;
-    }
-
-    // Getters and Setters
-    public Long getEntityId() {
-        return entityId;
-    }
-
-    public void setEntityId(Long entityId) {
-        this.entityId = entityId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Boolean getDefaultForEntity() {
-        return defaultForEntity;
-    }
-
-    public void setDefaultForEntity(Boolean defaultForEntity) {
-        this.defaultForEntity = defaultForEntity;
-    }
-
-    public List<Long> getFenceIds() {
-        return fenceIds;
-    }
-
-    public void setFenceIds(List<Long> fenceIds) {
-        this.fenceIds = fenceIds;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/assignment/AssignmentSummary.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/AssignmentSummary.java
@@ -1,14 +1,20 @@
 package com.tse.core_application.dto.assignment;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class AssignmentSummary {
     private int added = 0;
     private int removed = 0;
     private int updatedDefault = 0;
     private int noops = 0;
     private int errors = 0;
-
-    public AssignmentSummary() {
-    }
 
     public void incrementAdded() {
         added++;
@@ -28,46 +34,5 @@ public class AssignmentSummary {
 
     public void incrementErrors() {
         errors++;
-    }
-
-    // Getters and Setters
-    public int getAdded() {
-        return added;
-    }
-
-    public void setAdded(int added) {
-        this.added = added;
-    }
-
-    public int getRemoved() {
-        return removed;
-    }
-
-    public void setRemoved(int removed) {
-        this.removed = removed;
-    }
-
-    public int getUpdatedDefault() {
-        return updatedDefault;
-    }
-
-    public void setUpdatedDefault(int updatedDefault) {
-        this.updatedDefault = updatedDefault;
-    }
-
-    public int getNoops() {
-        return noops;
-    }
-
-    public void setNoops(int noops) {
-        this.noops = noops;
-    }
-
-    public int getErrors() {
-        return errors;
-    }
-
-    public void setErrors(int errors) {
-        this.errors = errors;
     }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/assignment/EntityActionItem.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/EntityActionItem.java
@@ -1,35 +1,16 @@
 package com.tse.core_application.dto.assignment;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class EntityActionItem {
     private Integer entityTypeId;
     private Long entityId;
     private Boolean makeDefault;
-
-    public EntityActionItem() {
-    }
-
-    // Getters and Setters
-    public Integer getEntityTypeId() {
-        return entityTypeId;
-    }
-
-    public void setEntityTypeId(Integer entityTypeId) {
-        this.entityTypeId = entityTypeId;
-    }
-
-    public Long getEntityId() {
-        return entityId;
-    }
-
-    public void setEntityId(Long entityId) {
-        this.entityId = entityId;
-    }
-
-    public Boolean getMakeDefault() {
-        return makeDefault;
-    }
-
-    public void setMakeDefault(Boolean makeDefault) {
-        this.makeDefault = makeDefault;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/assignment/EntityCounts.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/EntityCounts.java
@@ -1,51 +1,17 @@
 package com.tse.core_application.dto.assignment;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class EntityCounts {
     private int users = 0;
     private int teams = 0;
     private int projects = 0;
     private int orgs = 0;
-
-    public EntityCounts() {
-    }
-
-    public EntityCounts(int users, int teams, int projects, int orgs) {
-        this.users = users;
-        this.teams = teams;
-        this.projects = projects;
-        this.orgs = orgs;
-    }
-
-    // Getters and Setters
-    public int getUsers() {
-        return users;
-    }
-
-    public void setUsers(int users) {
-        this.users = users;
-    }
-
-    public int getTeams() {
-        return teams;
-    }
-
-    public void setTeams(int teams) {
-        this.teams = teams;
-    }
-
-    public int getProjects() {
-        return projects;
-    }
-
-    public void setProjects(int projects) {
-        this.projects = projects;
-    }
-
-    public int getOrgs() {
-        return orgs;
-    }
-
-    public void setOrgs(int orgs) {
-        this.orgs = orgs;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/assignment/EntityLists.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/EntityLists.java
@@ -2,46 +2,18 @@ package com.tse.core_application.dto.assignment;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class EntityLists {
     private List<AssignedEntity> users = new ArrayList<>();
     private List<AssignedEntity> teams = new ArrayList<>();
     private List<AssignedEntity> projects = new ArrayList<>();
     private List<AssignedEntity> orgs = new ArrayList<>();
-
-    public EntityLists() {
-    }
-
-    // Getters and Setters
-    public List<AssignedEntity> getUsers() {
-        return users;
-    }
-
-    public void setUsers(List<AssignedEntity> users) {
-        this.users = users;
-    }
-
-    public List<AssignedEntity> getTeams() {
-        return teams;
-    }
-
-    public void setTeams(List<AssignedEntity> teams) {
-        this.teams = teams;
-    }
-
-    public List<AssignedEntity> getProjects() {
-        return projects;
-    }
-
-    public void setProjects(List<AssignedEntity> projects) {
-        this.projects = projects;
-    }
-
-    public List<AssignedEntity> getOrgs() {
-        return orgs;
-    }
-
-    public void setOrgs(List<AssignedEntity> orgs) {
-        this.orgs = orgs;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/assignment/EntityResult.java
+++ b/backend/src/main/java/com/tse/core_application/dto/assignment/EntityResult.java
@@ -3,7 +3,15 @@ package com.tse.core_application.dto.assignment;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class EntityResult {
     private Integer entityTypeId;
@@ -12,65 +20,4 @@ public class EntityResult {
     private Boolean defaultForEntity;
     private List<Long> fenceIds;
     private String message;
-
-    public EntityResult() {
-    }
-
-    public EntityResult(Integer entityTypeId, Long entityId, String action, Boolean defaultForEntity, List<Long> fenceIds, String message) {
-        this.entityTypeId = entityTypeId;
-        this.entityId = entityId;
-        this.action = action;
-        this.defaultForEntity = defaultForEntity;
-        this.fenceIds = fenceIds;
-        this.message = message;
-    }
-
-    // Getters and Setters
-    public Integer getEntityTypeId() {
-        return entityTypeId;
-    }
-
-    public void setEntityTypeId(Integer entityTypeId) {
-        this.entityTypeId = entityTypeId;
-    }
-
-    public Long getEntityId() {
-        return entityId;
-    }
-
-    public void setEntityId(Long entityId) {
-        this.entityId = entityId;
-    }
-
-    public String getAction() {
-        return action;
-    }
-
-    public void setAction(String action) {
-        this.action = action;
-    }
-
-    public Boolean getDefaultForEntity() {
-        return defaultForEntity;
-    }
-
-    public void setDefaultForEntity(Boolean defaultForEntity) {
-        this.defaultForEntity = defaultForEntity;
-    }
-
-    public List<Long> getFenceIds() {
-        return fenceIds;
-    }
-
-    public void setFenceIds(List<Long> fenceIds) {
-        this.fenceIds = fenceIds;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/attendance/PunchCreateRequest.java
+++ b/backend/src/main/java/com/tse/core_application/dto/attendance/PunchCreateRequest.java
@@ -1,10 +1,18 @@
 package com.tse.core_application.dto.attendance;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Phase 6b: Request body for POST /api/orgs/{orgId}/attendance/punch
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PunchCreateRequest {
 
     @JsonProperty("accountId")
@@ -30,71 +38,4 @@ public class PunchCreateRequest {
 
     @JsonProperty("idempotencyKey")
     private String idempotencyKey;
-
-    public PunchCreateRequest() {
-    }
-
-    public Long getAccountId() {
-        return accountId;
-    }
-
-    public void setAccountId(Long accountId) {
-        this.accountId = accountId;
-    }
-
-    public String getEventKind() {
-        return eventKind;
-    }
-
-    public void setEventKind(String eventKind) {
-        this.eventKind = eventKind;
-    }
-
-    public Double getLat() {
-        return lat;
-    }
-
-    public void setLat(Double lat) {
-        this.lat = lat;
-    }
-
-    public Double getLon() {
-        return lon;
-    }
-
-    public void setLon(Double lon) {
-        this.lon = lon;
-    }
-
-    public Double getAccuracyM() {
-        return accuracyM;
-    }
-
-    public void setAccuracyM(Double accuracyM) {
-        this.accuracyM = accuracyM;
-    }
-
-    public String getClientLocalTs() {
-        return clientLocalTs;
-    }
-
-    public void setClientLocalTs(String clientLocalTs) {
-        this.clientLocalTs = clientLocalTs;
-    }
-
-    public String getClientTz() {
-        return clientTz;
-    }
-
-    public void setClientTz(String clientTz) {
-        this.clientTz = clientTz;
-    }
-
-    public String getIdempotencyKey() {
-        return idempotencyKey;
-    }
-
-    public void setIdempotencyKey(String idempotencyKey) {
-        this.idempotencyKey = idempotencyKey;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/attendance/PunchResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/attendance/PunchResponse.java
@@ -3,10 +3,18 @@ package com.tse.core_application.dto.attendance;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Phase 6b: Response for POST /api/orgs/{orgId}/attendance/punch
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PunchResponse {
 
     @JsonProperty("eventId")
@@ -41,95 +49,4 @@ public class PunchResponse {
 
     @JsonProperty("flags")
     private Map<String, Object> flags;
-
-    public PunchResponse() {
-    }
-
-    public Long getEventId() {
-        return eventId;
-    }
-
-    public void setEventId(Long eventId) {
-        this.eventId = eventId;
-    }
-
-    public Long getAccountId() {
-        return accountId;
-    }
-
-    public void setAccountId(Long accountId) {
-        this.accountId = accountId;
-    }
-
-    public String getEventKind() {
-        return eventKind;
-    }
-
-    public void setEventKind(String eventKind) {
-        this.eventKind = eventKind;
-    }
-
-    public String getEventSource() {
-        return eventSource;
-    }
-
-    public void setEventSource(String eventSource) {
-        this.eventSource = eventSource;
-    }
-
-    public String getTsUtc() {
-        return tsUtc;
-    }
-
-    public void setTsUtc(String tsUtc) {
-        this.tsUtc = tsUtc;
-    }
-
-    public Long getFenceId() {
-        return fenceId;
-    }
-
-    public void setFenceId(Long fenceId) {
-        this.fenceId = fenceId;
-    }
-
-    public Boolean getUnderRange() {
-        return underRange;
-    }
-
-    public void setUnderRange(Boolean underRange) {
-        this.underRange = underRange;
-    }
-
-    public Boolean getSuccess() {
-        return success;
-    }
-
-    public void setSuccess(Boolean success) {
-        this.success = success;
-    }
-
-    public String getVerdict() {
-        return verdict;
-    }
-
-    public void setVerdict(String verdict) {
-        this.verdict = verdict;
-    }
-
-    public String getFailReason() {
-        return failReason;
-    }
-
-    public void setFailReason(String failReason) {
-        this.failReason = failReason;
-    }
-
-    public Map<String, Object> getFlags() {
-        return flags;
-    }
-
-    public void setFlags(Map<String, Object> flags) {
-        this.flags = flags;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/attendance/TodaySummaryResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/attendance/TodaySummaryResponse.java
@@ -3,10 +3,18 @@ package com.tse.core_application.dto.attendance;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Phase 6b: Response for GET /api/orgs/{orgId}/attendance/today
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class TodaySummaryResponse {
 
     @JsonProperty("accountId")
@@ -33,73 +41,10 @@ public class TodaySummaryResponse {
     @JsonProperty("events")
     private List<EventSummary> events;
 
-    public TodaySummaryResponse() {
-    }
-
-    public Long getAccountId() {
-        return accountId;
-    }
-
-    public void setAccountId(Long accountId) {
-        this.accountId = accountId;
-    }
-
-    public String getDateKey() {
-        return dateKey;
-    }
-
-    public void setDateKey(String dateKey) {
-        this.dateKey = dateKey;
-    }
-
-    public String getCurrentStatus() {
-        return currentStatus;
-    }
-
-    public void setCurrentStatus(String currentStatus) {
-        this.currentStatus = currentStatus;
-    }
-
-    public String getFirstInUtc() {
-        return firstInUtc;
-    }
-
-    public void setFirstInUtc(String firstInUtc) {
-        this.firstInUtc = firstInUtc;
-    }
-
-    public String getLastOutUtc() {
-        return lastOutUtc;
-    }
-
-    public void setLastOutUtc(String lastOutUtc) {
-        this.lastOutUtc = lastOutUtc;
-    }
-
-    public Integer getWorkedSeconds() {
-        return workedSeconds;
-    }
-
-    public void setWorkedSeconds(Integer workedSeconds) {
-        this.workedSeconds = workedSeconds;
-    }
-
-    public Integer getBreakSeconds() {
-        return breakSeconds;
-    }
-
-    public void setBreakSeconds(Integer breakSeconds) {
-        this.breakSeconds = breakSeconds;
-    }
-
-    public List<EventSummary> getEvents() {
-        return events;
-    }
-
-    public void setEvents(List<EventSummary> events) {
-        this.events = events;
-    }
-
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class EventSummary {
         @JsonProperty("eventId")
         private Long eventId;
@@ -115,48 +60,5 @@ public class TodaySummaryResponse {
 
         @JsonProperty("verdict")
         private String verdict;
-
-        public EventSummary() {
-        }
-
-        public Long getEventId() {
-            return eventId;
-        }
-
-        public void setEventId(Long eventId) {
-            this.eventId = eventId;
-        }
-
-        public String getEventKind() {
-            return eventKind;
-        }
-
-        public void setEventKind(String eventKind) {
-            this.eventKind = eventKind;
-        }
-
-        public String getTsUtc() {
-            return tsUtc;
-        }
-
-        public void setTsUtc(String tsUtc) {
-            this.tsUtc = tsUtc;
-        }
-
-        public Boolean getSuccess() {
-            return success;
-        }
-
-        public void setSuccess(Boolean success) {
-            this.success = success;
-        }
-
-        public String getVerdict() {
-            return verdict;
-        }
-
-        public void setVerdict(String verdict) {
-            this.verdict = verdict;
-        }
     }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/fence/FenceCreateRequest.java
+++ b/backend/src/main/java/com/tse/core_application/dto/fence/FenceCreateRequest.java
@@ -3,7 +3,15 @@ package com.tse.core_application.dto.fence;
 import com.tse.core_application.entity.fence.GeoFence.LocationKind;
 
 import javax.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class FenceCreateRequest {
 
     @NotBlank
@@ -32,69 +40,4 @@ public class FenceCreateRequest {
     private Integer radiusM;
 
     private Long createdBy;
-
-    // Getters and Setters
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public LocationKind getLocationKind() {
-        return locationKind;
-    }
-
-    public void setLocationKind(LocationKind locationKind) {
-        this.locationKind = locationKind;
-    }
-
-    public String getSiteCode() {
-        return siteCode;
-    }
-
-    public void setSiteCode(String siteCode) {
-        this.siteCode = siteCode;
-    }
-
-    public String getTz() {
-        return tz;
-    }
-
-    public void setTz(String tz) {
-        this.tz = tz;
-    }
-
-    public Double getCenterLat() {
-        return centerLat;
-    }
-
-    public void setCenterLat(Double centerLat) {
-        this.centerLat = centerLat;
-    }
-
-    public Double getCenterLng() {
-        return centerLng;
-    }
-
-    public void setCenterLng(Double centerLng) {
-        this.centerLng = centerLng;
-    }
-
-    public Integer getRadiusM() {
-        return radiusM;
-    }
-
-    public void setRadiusM(Integer radiusM) {
-        this.radiusM = radiusM;
-    }
-
-    public Long getCreatedBy() {
-        return createdBy;
-    }
-
-    public void setCreatedBy(Long createdBy) {
-        this.createdBy = createdBy;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/fence/FenceResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/fence/FenceResponse.java
@@ -5,7 +5,15 @@ import com.tse.core_application.entity.fence.GeoFence;
 import com.tse.core_application.entity.fence.GeoFence.LocationKind;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class FenceResponse {
 
@@ -24,9 +32,6 @@ public class FenceResponse {
     private Long updatedBy;
     private LocalDateTime updatedDatetime;
 
-    public FenceResponse() {
-    }
-
     public static FenceResponse fromEntity(GeoFence fence) {
         FenceResponse response = new FenceResponse();
         response.setId(fence.getId());
@@ -44,118 +49,5 @@ public class FenceResponse {
         response.setUpdatedBy(fence.getUpdatedBy());
         response.setUpdatedDatetime(fence.getUpdatedDatetime());
         return response;
-    }
-
-    // Getters and Setters
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Long getOrgId() {
-        return orgId;
-    }
-
-    public void setOrgId(Long orgId) {
-        this.orgId = orgId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public LocationKind getLocationKind() {
-        return locationKind;
-    }
-
-    public void setLocationKind(LocationKind locationKind) {
-        this.locationKind = locationKind;
-    }
-
-    public String getSiteCode() {
-        return siteCode;
-    }
-
-    public void setSiteCode(String siteCode) {
-        this.siteCode = siteCode;
-    }
-
-    public String getTz() {
-        return tz;
-    }
-
-    public void setTz(String tz) {
-        this.tz = tz;
-    }
-
-    public Double getCenterLat() {
-        return centerLat;
-    }
-
-    public void setCenterLat(Double centerLat) {
-        this.centerLat = centerLat;
-    }
-
-    public Double getCenterLng() {
-        return centerLng;
-    }
-
-    public void setCenterLng(Double centerLng) {
-        this.centerLng = centerLng;
-    }
-
-    public Integer getRadiusM() {
-        return radiusM;
-    }
-
-    public void setRadiusM(Integer radiusM) {
-        this.radiusM = radiusM;
-    }
-
-    public Boolean getIsActive() {
-        return isActive;
-    }
-
-    public void setIsActive(Boolean isActive) {
-        this.isActive = isActive;
-    }
-
-    public Long getCreatedBy() {
-        return createdBy;
-    }
-
-    public void setCreatedBy(Long createdBy) {
-        this.createdBy = createdBy;
-    }
-
-    public LocalDateTime getCreatedDatetime() {
-        return createdDatetime;
-    }
-
-    public void setCreatedDatetime(LocalDateTime createdDatetime) {
-        this.createdDatetime = createdDatetime;
-    }
-
-    public Long getUpdatedBy() {
-        return updatedBy;
-    }
-
-    public void setUpdatedBy(Long updatedBy) {
-        this.updatedBy = updatedBy;
-    }
-
-    public LocalDateTime getUpdatedDatetime() {
-        return updatedDatetime;
-    }
-
-    public void setUpdatedDatetime(LocalDateTime updatedDatetime) {
-        this.updatedDatetime = updatedDatetime;
     }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/fence/FenceUpdateRequest.java
+++ b/backend/src/main/java/com/tse/core_application/dto/fence/FenceUpdateRequest.java
@@ -3,7 +3,15 @@ package com.tse.core_application.dto.fence;
 import com.tse.core_application.entity.fence.GeoFence.LocationKind;
 
 import javax.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class FenceUpdateRequest {
 
     @NotNull
@@ -38,85 +46,4 @@ public class FenceUpdateRequest {
     private Boolean isActive;
 
     private Long updatedBy;
-
-    // Getters and Setters
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public LocationKind getLocationKind() {
-        return locationKind;
-    }
-
-    public void setLocationKind(LocationKind locationKind) {
-        this.locationKind = locationKind;
-    }
-
-    public String getSiteCode() {
-        return siteCode;
-    }
-
-    public void setSiteCode(String siteCode) {
-        this.siteCode = siteCode;
-    }
-
-    public String getTz() {
-        return tz;
-    }
-
-    public void setTz(String tz) {
-        this.tz = tz;
-    }
-
-    public Double getCenterLat() {
-        return centerLat;
-    }
-
-    public void setCenterLat(Double centerLat) {
-        this.centerLat = centerLat;
-    }
-
-    public Double getCenterLng() {
-        return centerLng;
-    }
-
-    public void setCenterLng(Double centerLng) {
-        this.centerLng = centerLng;
-    }
-
-    public Integer getRadiusM() {
-        return radiusM;
-    }
-
-    public void setRadiusM(Integer radiusM) {
-        this.radiusM = radiusM;
-    }
-
-    public Boolean getIsActive() {
-        return isActive;
-    }
-
-    public void setIsActive(Boolean isActive) {
-        this.isActive = isActive;
-    }
-
-    public Long getUpdatedBy() {
-        return updatedBy;
-    }
-
-    public void setUpdatedBy(Long updatedBy) {
-        this.updatedBy = updatedBy;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/policy/PolicyCreateRequest.java
+++ b/backend/src/main/java/com/tse/core_application/dto/policy/PolicyCreateRequest.java
@@ -1,17 +1,15 @@
 package com.tse.core_application.dto.policy;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PolicyCreateRequest {
 
     private Long createdBy;
-
-    public PolicyCreateRequest() {
-    }
-
-    public Long getCreatedBy() {
-        return createdBy;
-    }
-
-    public void setCreatedBy(Long createdBy) {
-        this.createdBy = createdBy;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/policy/PolicyResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/policy/PolicyResponse.java
@@ -6,7 +6,15 @@ import com.tse.core_application.entity.policy.AttendancePolicy.IntegrityPosture;
 import com.tse.core_application.entity.policy.AttendancePolicy.OutsideFencePolicy;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PolicyResponse {
 
@@ -47,9 +55,6 @@ public class PolicyResponse {
     private Long updatedBy;
     private LocalDateTime updatedDatetime;
 
-    public PolicyResponse() {
-    }
-
     // Factory method for full policy
     public static PolicyResponse fromEntity(AttendancePolicy policy) {
         PolicyResponse response = new PolicyResponse();
@@ -79,230 +84,5 @@ public class PolicyResponse {
         response.setUpdatedBy(policy.getUpdatedBy());
         response.setUpdatedDatetime(policy.getUpdatedDatetime());
         return response;
-    }
-
-    // Getters and Setters
-    public Long getPolicyId() {
-        return policyId;
-    }
-
-    public void setPolicyId(Long policyId) {
-        this.policyId = policyId;
-    }
-
-    public Long getOrgId() {
-        return orgId;
-    }
-
-    public void setOrgId(Long orgId) {
-        this.orgId = orgId;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public void setStatus(String status) {
-        this.status = status;
-    }
-
-    public Boolean getDefaultsApplied() {
-        return defaultsApplied;
-    }
-
-    public void setDefaultsApplied(Boolean defaultsApplied) {
-        this.defaultsApplied = defaultsApplied;
-    }
-
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public Boolean getIsActive() {
-        return isActive;
-    }
-
-    public void setIsActive(Boolean isActive) {
-        this.isActive = isActive;
-    }
-
-    public OutsideFencePolicy getOutsideFencePolicy() {
-        return outsideFencePolicy;
-    }
-
-    public void setOutsideFencePolicy(OutsideFencePolicy outsideFencePolicy) {
-        this.outsideFencePolicy = outsideFencePolicy;
-    }
-
-    public IntegrityPosture getIntegrityPosture() {
-        return integrityPosture;
-    }
-
-    public void setIntegrityPosture(IntegrityPosture integrityPosture) {
-        this.integrityPosture = integrityPosture;
-    }
-
-    public Integer getAllowCheckinBeforeStartMin() {
-        return allowCheckinBeforeStartMin;
-    }
-
-    public void setAllowCheckinBeforeStartMin(Integer allowCheckinBeforeStartMin) {
-        this.allowCheckinBeforeStartMin = allowCheckinBeforeStartMin;
-    }
-
-    public Integer getLateCheckinAfterStartMin() {
-        return lateCheckinAfterStartMin;
-    }
-
-    public void setLateCheckinAfterStartMin(Integer lateCheckinAfterStartMin) {
-        this.lateCheckinAfterStartMin = lateCheckinAfterStartMin;
-    }
-
-    public Integer getAllowCheckoutBeforeEndMin() {
-        return allowCheckoutBeforeEndMin;
-    }
-
-    public void setAllowCheckoutBeforeEndMin(Integer allowCheckoutBeforeEndMin) {
-        this.allowCheckoutBeforeEndMin = allowCheckoutBeforeEndMin;
-    }
-
-    public Integer getMaxCheckoutAfterEndMin() {
-        return maxCheckoutAfterEndMin;
-    }
-
-    public void setMaxCheckoutAfterEndMin(Integer maxCheckoutAfterEndMin) {
-        this.maxCheckoutAfterEndMin = maxCheckoutAfterEndMin;
-    }
-
-    public Integer getNotifyBeforeShiftStartMin() {
-        return notifyBeforeShiftStartMin;
-    }
-
-    public void setNotifyBeforeShiftStartMin(Integer notifyBeforeShiftStartMin) {
-        this.notifyBeforeShiftStartMin = notifyBeforeShiftStartMin;
-    }
-
-    public Integer getFenceRadiusM() {
-        return fenceRadiusM;
-    }
-
-    public void setFenceRadiusM(Integer fenceRadiusM) {
-        this.fenceRadiusM = fenceRadiusM;
-    }
-
-    public Integer getAccuracyGateM() {
-        return accuracyGateM;
-    }
-
-    public void setAccuracyGateM(Integer accuracyGateM) {
-        this.accuracyGateM = accuracyGateM;
-    }
-
-    public Integer getCooldownSeconds() {
-        return cooldownSeconds;
-    }
-
-    public void setCooldownSeconds(Integer cooldownSeconds) {
-        this.cooldownSeconds = cooldownSeconds;
-    }
-
-    public Integer getMaxSuccessfulPunchesPerDay() {
-        return maxSuccessfulPunchesPerDay;
-    }
-
-    public void setMaxSuccessfulPunchesPerDay(Integer maxSuccessfulPunchesPerDay) {
-        this.maxSuccessfulPunchesPerDay = maxSuccessfulPunchesPerDay;
-    }
-
-    public Integer getMaxFailedPunchesPerDay() {
-        return maxFailedPunchesPerDay;
-    }
-
-    public void setMaxFailedPunchesPerDay(Integer maxFailedPunchesPerDay) {
-        this.maxFailedPunchesPerDay = maxFailedPunchesPerDay;
-    }
-
-    public Integer getMaxWorkingHoursPerDay() {
-        return maxWorkingHoursPerDay;
-    }
-
-    public void setMaxWorkingHoursPerDay(Integer maxWorkingHoursPerDay) {
-        this.maxWorkingHoursPerDay = maxWorkingHoursPerDay;
-    }
-
-    public Integer getDwellInMin() {
-        return dwellInMin;
-    }
-
-    public void setDwellInMin(Integer dwellInMin) {
-        this.dwellInMin = dwellInMin;
-    }
-
-    public Integer getDwellOutMin() {
-        return dwellOutMin;
-    }
-
-    public void setDwellOutMin(Integer dwellOutMin) {
-        this.dwellOutMin = dwellOutMin;
-    }
-
-    public Boolean getAutoOutEnabled() {
-        return autoOutEnabled;
-    }
-
-    public void setAutoOutEnabled(Boolean autoOutEnabled) {
-        this.autoOutEnabled = autoOutEnabled;
-    }
-
-    public Integer getAutoOutDelayMin() {
-        return autoOutDelayMin;
-    }
-
-    public void setAutoOutDelayMin(Integer autoOutDelayMin) {
-        this.autoOutDelayMin = autoOutDelayMin;
-    }
-
-    public Integer getUndoWindowMin() {
-        return undoWindowMin;
-    }
-
-    public void setUndoWindowMin(Integer undoWindowMin) {
-        this.undoWindowMin = undoWindowMin;
-    }
-
-    public Long getCreatedBy() {
-        return createdBy;
-    }
-
-    public void setCreatedBy(Long createdBy) {
-        this.createdBy = createdBy;
-    }
-
-    public LocalDateTime getCreatedDatetime() {
-        return createdDatetime;
-    }
-
-    public void setCreatedDatetime(LocalDateTime createdDatetime) {
-        this.createdDatetime = createdDatetime;
-    }
-
-    public Long getUpdatedBy() {
-        return updatedBy;
-    }
-
-    public void setUpdatedBy(Long updatedBy) {
-        this.updatedBy = updatedBy;
-    }
-
-    public LocalDateTime getUpdatedDatetime() {
-        return updatedDatetime;
-    }
-
-    public void setUpdatedDatetime(LocalDateTime updatedDatetime) {
-        this.updatedDatetime = updatedDatetime;
     }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/policy/PolicyUpdateRequest.java
+++ b/backend/src/main/java/com/tse/core_application/dto/policy/PolicyUpdateRequest.java
@@ -5,7 +5,15 @@ import com.tse.core_application.entity.policy.AttendancePolicy.OutsideFencePolic
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PolicyUpdateRequest {
 
     private Long updatedBy;
@@ -87,165 +95,4 @@ public class PolicyUpdateRequest {
     @NotNull
     @Min(0)
     private Integer undoWindowMin;
-
-    // Getters and Setters
-    public Long getUpdatedBy() {
-        return updatedBy;
-    }
-
-    public void setUpdatedBy(Long updatedBy) {
-        this.updatedBy = updatedBy;
-    }
-
-    public Boolean getIsActive() {
-        return isActive;
-    }
-
-    public void setIsActive(Boolean isActive) {
-        this.isActive = isActive;
-    }
-
-    public OutsideFencePolicy getOutsideFencePolicy() {
-        return outsideFencePolicy;
-    }
-
-    public void setOutsideFencePolicy(OutsideFencePolicy outsideFencePolicy) {
-        this.outsideFencePolicy = outsideFencePolicy;
-    }
-
-    public IntegrityPosture getIntegrityPosture() {
-        return integrityPosture;
-    }
-
-    public void setIntegrityPosture(IntegrityPosture integrityPosture) {
-        this.integrityPosture = integrityPosture;
-    }
-
-    public Integer getAllowCheckinBeforeStartMin() {
-        return allowCheckinBeforeStartMin;
-    }
-
-    public void setAllowCheckinBeforeStartMin(Integer allowCheckinBeforeStartMin) {
-        this.allowCheckinBeforeStartMin = allowCheckinBeforeStartMin;
-    }
-
-    public Integer getLateCheckinAfterStartMin() {
-        return lateCheckinAfterStartMin;
-    }
-
-    public void setLateCheckinAfterStartMin(Integer lateCheckinAfterStartMin) {
-        this.lateCheckinAfterStartMin = lateCheckinAfterStartMin;
-    }
-
-    public Integer getAllowCheckoutBeforeEndMin() {
-        return allowCheckoutBeforeEndMin;
-    }
-
-    public void setAllowCheckoutBeforeEndMin(Integer allowCheckoutBeforeEndMin) {
-        this.allowCheckoutBeforeEndMin = allowCheckoutBeforeEndMin;
-    }
-
-    public Integer getMaxCheckoutAfterEndMin() {
-        return maxCheckoutAfterEndMin;
-    }
-
-    public void setMaxCheckoutAfterEndMin(Integer maxCheckoutAfterEndMin) {
-        this.maxCheckoutAfterEndMin = maxCheckoutAfterEndMin;
-    }
-
-    public Integer getNotifyBeforeShiftStartMin() {
-        return notifyBeforeShiftStartMin;
-    }
-
-    public void setNotifyBeforeShiftStartMin(Integer notifyBeforeShiftStartMin) {
-        this.notifyBeforeShiftStartMin = notifyBeforeShiftStartMin;
-    }
-
-    public Integer getFenceRadiusM() {
-        return fenceRadiusM;
-    }
-
-    public void setFenceRadiusM(Integer fenceRadiusM) {
-        this.fenceRadiusM = fenceRadiusM;
-    }
-
-    public Integer getAccuracyGateM() {
-        return accuracyGateM;
-    }
-
-    public void setAccuracyGateM(Integer accuracyGateM) {
-        this.accuracyGateM = accuracyGateM;
-    }
-
-    public Integer getCooldownSeconds() {
-        return cooldownSeconds;
-    }
-
-    public void setCooldownSeconds(Integer cooldownSeconds) {
-        this.cooldownSeconds = cooldownSeconds;
-    }
-
-    public Integer getMaxSuccessfulPunchesPerDay() {
-        return maxSuccessfulPunchesPerDay;
-    }
-
-    public void setMaxSuccessfulPunchesPerDay(Integer maxSuccessfulPunchesPerDay) {
-        this.maxSuccessfulPunchesPerDay = maxSuccessfulPunchesPerDay;
-    }
-
-    public Integer getMaxFailedPunchesPerDay() {
-        return maxFailedPunchesPerDay;
-    }
-
-    public void setMaxFailedPunchesPerDay(Integer maxFailedPunchesPerDay) {
-        this.maxFailedPunchesPerDay = maxFailedPunchesPerDay;
-    }
-
-    public Integer getMaxWorkingHoursPerDay() {
-        return maxWorkingHoursPerDay;
-    }
-
-    public void setMaxWorkingHoursPerDay(Integer maxWorkingHoursPerDay) {
-        this.maxWorkingHoursPerDay = maxWorkingHoursPerDay;
-    }
-
-    public Integer getDwellInMin() {
-        return dwellInMin;
-    }
-
-    public void setDwellInMin(Integer dwellInMin) {
-        this.dwellInMin = dwellInMin;
-    }
-
-    public Integer getDwellOutMin() {
-        return dwellOutMin;
-    }
-
-    public void setDwellOutMin(Integer dwellOutMin) {
-        this.dwellOutMin = dwellOutMin;
-    }
-
-    public Boolean getAutoOutEnabled() {
-        return autoOutEnabled;
-    }
-
-    public void setAutoOutEnabled(Boolean autoOutEnabled) {
-        this.autoOutEnabled = autoOutEnabled;
-    }
-
-    public Integer getAutoOutDelayMin() {
-        return autoOutDelayMin;
-    }
-
-    public void setAutoOutDelayMin(Integer autoOutDelayMin) {
-        this.autoOutDelayMin = autoOutDelayMin;
-    }
-
-    public Integer getUndoWindowMin() {
-        return undoWindowMin;
-    }
-
-    public void setUndoWindowMin(Integer undoWindowMin) {
-        this.undoWindowMin = undoWindowMin;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/punch/PunchRequestCreateDto.java
+++ b/backend/src/main/java/com/tse/core_application/dto/punch/PunchRequestCreateDto.java
@@ -5,10 +5,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * DTO for creating a new punch request.
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PunchRequestCreateDto {
 
     @NotNull(message = "entityTypeId is required")
@@ -31,47 +39,4 @@ public class PunchRequestCreateDto {
     @Min(value = 1, message = "respondWithinMinutes must be at least 1")
     @JsonProperty("respondWithinMinutes")
     private Integer respondWithinMinutes;
-
-    public PunchRequestCreateDto() {
-    }
-
-    public Integer getEntityTypeId() {
-        return entityTypeId;
-    }
-
-    public void setEntityTypeId(Integer entityTypeId) {
-        this.entityTypeId = entityTypeId;
-    }
-
-    public Long getEntityId() {
-        return entityId;
-    }
-
-    public void setEntityId(Long entityId) {
-        this.entityId = entityId;
-    }
-
-    public Long getRequesterAccountId() {
-        return requesterAccountId;
-    }
-
-    public void setRequesterAccountId(Long requesterAccountId) {
-        this.requesterAccountId = requesterAccountId;
-    }
-
-    public LocalDateTime getRequestedDateTime() {
-        return requestedDateTime;
-    }
-
-    public void setRequestedDateTime(LocalDateTime requestedDateTime) {
-        this.requestedDateTime = requestedDateTime;
-    }
-
-    public Integer getRespondWithinMinutes() {
-        return respondWithinMinutes;
-    }
-
-    public void setRespondWithinMinutes(Integer respondWithinMinutes) {
-        this.respondWithinMinutes = respondWithinMinutes;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/punch/PunchRequestViewDto.java
+++ b/backend/src/main/java/com/tse/core_application/dto/punch/PunchRequestViewDto.java
@@ -5,10 +5,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * DTO for viewing a punch request with computed fields.
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PunchRequestViewDto {
 
     @JsonProperty("id")
@@ -46,103 +54,4 @@ public class PunchRequestViewDto {
 
     @JsonProperty("appliesToAccountIds")
     private List<Long> appliesToAccountIds = new ArrayList<>(); // optional: which accounts this applies to
-
-    public PunchRequestViewDto() {
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Long getOrgId() {
-        return orgId;
-    }
-
-    public void setOrgId(Long orgId) {
-        this.orgId = orgId;
-    }
-
-    public Integer getEntityTypeId() {
-        return entityTypeId;
-    }
-
-    public void setEntityTypeId(Integer entityTypeId) {
-        this.entityTypeId = entityTypeId;
-    }
-
-    public Long getEntityId() {
-        return entityId;
-    }
-
-    public void setEntityId(Long entityId) {
-        this.entityId = entityId;
-    }
-
-    public Long getRequesterAccountId() {
-        return requesterAccountId;
-    }
-
-    public void setRequesterAccountId(Long requesterAccountId) {
-        this.requesterAccountId = requesterAccountId;
-    }
-
-    public LocalDateTime getRequestedDateTime() {
-        return requestedDateTime;
-    }
-
-    public void setRequestedDateTime(LocalDateTime requestedDateTime) {
-        this.requestedDateTime = requestedDateTime;
-    }
-
-    public Integer getRespondWithinMinutes() {
-        return respondWithinMinutes;
-    }
-
-    public void setRespondWithinMinutes(Integer respondWithinMinutes) {
-        this.respondWithinMinutes = respondWithinMinutes;
-    }
-
-    public LocalDateTime getExpiresAt() {
-        return expiresAt;
-    }
-
-    public void setExpiresAt(LocalDateTime expiresAt) {
-        this.expiresAt = expiresAt;
-    }
-
-    public String getState() {
-        return state;
-    }
-
-    public void setState(String state) {
-        this.state = state;
-    }
-
-    public Boolean getActiveNow() {
-        return activeNow;
-    }
-
-    public void setActiveNow(Boolean activeNow) {
-        this.activeNow = activeNow;
-    }
-
-    public Long getSecondsRemaining() {
-        return secondsRemaining;
-    }
-
-    public void setSecondsRemaining(Long secondsRemaining) {
-        this.secondsRemaining = secondsRemaining;
-    }
-
-    public List<Long> getAppliesToAccountIds() {
-        return appliesToAccountIds;
-    }
-
-    public void setAppliesToAccountIds(List<Long> appliesToAccountIds) {
-        this.appliesToAccountIds = appliesToAccountIds;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/userfence/Counts.java
+++ b/backend/src/main/java/com/tse/core_application/dto/userfence/Counts.java
@@ -1,10 +1,18 @@
 package com.tse.core_application.dto.userfence;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Aggregated counts of fence sources by entity type.
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Counts {
 
     @JsonProperty("total")
@@ -21,55 +29,4 @@ public class Counts {
 
     @JsonProperty("org")
     private int org;
-
-    public Counts() {
-    }
-
-    public Counts(int total, int user, int team, int project, int org) {
-        this.total = total;
-        this.user = user;
-        this.team = team;
-        this.project = project;
-        this.org = org;
-    }
-
-    public int getTotal() {
-        return total;
-    }
-
-    public void setTotal(int total) {
-        this.total = total;
-    }
-
-    public int getUser() {
-        return user;
-    }
-
-    public void setUser(int user) {
-        this.user = user;
-    }
-
-    public int getTeam() {
-        return team;
-    }
-
-    public void setTeam(int team) {
-        this.team = team;
-    }
-
-    public int getProject() {
-        return project;
-    }
-
-    public void setProject(int project) {
-        this.project = project;
-    }
-
-    public int getOrg() {
-        return org;
-    }
-
-    public void setOrg(int org) {
-        this.org = org;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/userfence/EffectiveFenceDto.java
+++ b/backend/src/main/java/com/tse/core_application/dto/userfence/EffectiveFenceDto.java
@@ -4,10 +4,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Represents an effective fence available to a user with all contributing sources.
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class EffectiveFenceDto {
 
     @JsonProperty("id")
@@ -39,87 +47,4 @@ public class EffectiveFenceDto {
 
     @JsonProperty("sources")
     private List<SourceRef> sources = new ArrayList<>();
-
-    public EffectiveFenceDto() {
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getLocationKind() {
-        return locationKind;
-    }
-
-    public void setLocationKind(String locationKind) {
-        this.locationKind = locationKind;
-    }
-
-    public String getSiteCode() {
-        return siteCode;
-    }
-
-    public void setSiteCode(String siteCode) {
-        this.siteCode = siteCode;
-    }
-
-    public String getTz() {
-        return tz;
-    }
-
-    public void setTz(String tz) {
-        this.tz = tz;
-    }
-
-    public Double getCenterLat() {
-        return centerLat;
-    }
-
-    public void setCenterLat(Double centerLat) {
-        this.centerLat = centerLat;
-    }
-
-    public Double getCenterLng() {
-        return centerLng;
-    }
-
-    public void setCenterLng(Double centerLng) {
-        this.centerLng = centerLng;
-    }
-
-    public Integer getRadiusM() {
-        return radiusM;
-    }
-
-    public void setRadiusM(Integer radiusM) {
-        this.radiusM = radiusM;
-    }
-
-    public Boolean getIsActive() {
-        return isActive;
-    }
-
-    public void setIsActive(Boolean isActive) {
-        this.isActive = isActive;
-    }
-
-    public List<SourceRef> getSources() {
-        return sources;
-    }
-
-    public void setSources(List<SourceRef> sources) {
-        this.sources = sources;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/userfence/SourceRef.java
+++ b/backend/src/main/java/com/tse/core_application/dto/userfence/SourceRef.java
@@ -1,10 +1,18 @@
 package com.tse.core_application.dto.userfence;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Represents the source of a fence assignment (entity that contributed the fence).
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class SourceRef {
 
     @JsonProperty("entityTypeId")
@@ -15,37 +23,4 @@ public class SourceRef {
 
     @JsonProperty("defaultForEntity")
     private Boolean defaultForEntity;
-
-    public SourceRef() {
-    }
-
-    public SourceRef(Integer entityTypeId, Long entityId, Boolean defaultForEntity) {
-        this.entityTypeId = entityTypeId;
-        this.entityId = entityId;
-        this.defaultForEntity = defaultForEntity;
-    }
-
-    public Integer getEntityTypeId() {
-        return entityTypeId;
-    }
-
-    public void setEntityTypeId(Integer entityTypeId) {
-        this.entityTypeId = entityTypeId;
-    }
-
-    public Long getEntityId() {
-        return entityId;
-    }
-
-    public void setEntityId(Long entityId) {
-        this.entityId = entityId;
-    }
-
-    public Boolean getDefaultForEntity() {
-        return defaultForEntity;
-    }
-
-    public void setDefaultForEntity(Boolean defaultForEntity) {
-        this.defaultForEntity = defaultForEntity;
-    }
 }

--- a/backend/src/main/java/com/tse/core_application/dto/userfence/UserFencesResponse.java
+++ b/backend/src/main/java/com/tse/core_application/dto/userfence/UserFencesResponse.java
@@ -4,10 +4,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Response containing all effective fences for a user in an organization.
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserFencesResponse {
 
     @JsonProperty("orgId")
@@ -24,47 +32,4 @@ public class UserFencesResponse {
 
     @JsonProperty("counts")
     private Counts counts;
-
-    public UserFencesResponse() {
-    }
-
-    public Long getOrgId() {
-        return orgId;
-    }
-
-    public void setOrgId(Long orgId) {
-        this.orgId = orgId;
-    }
-
-    public Long getAccountId() {
-        return accountId;
-    }
-
-    public void setAccountId(Long accountId) {
-        this.accountId = accountId;
-    }
-
-    public Long getDefaultFenceIdForUser() {
-        return defaultFenceIdForUser;
-    }
-
-    public void setDefaultFenceIdForUser(Long defaultFenceIdForUser) {
-        this.defaultFenceIdForUser = defaultFenceIdForUser;
-    }
-
-    public List<EffectiveFenceDto> getFences() {
-        return fences;
-    }
-
-    public void setFences(List<EffectiveFenceDto> fences) {
-        this.fences = fences;
-    }
-
-    public Counts getCounts() {
-        return counts;
-    }
-
-    public void setCounts(Counts counts) {
-        this.counts = counts;
-    }
 }


### PR DESCRIPTION
Replace manual getter/setter methods with Lombok annotations across all 24 DTO files:

DTOs Updated by Category:
- Policy DTOs (3): PolicyCreateRequest, PolicyUpdateRequest, PolicyResponse
- Fence DTOs (3): FenceCreateRequest, FenceUpdateRequest, FenceResponse
- Assignment DTOs (9): AssignFenceRequest, EntityResult, EntityLists, EntityCounts, EntityActionItem, AssignmentSummary, AssignedEntity, AssignedEntitiesResponse, AssignFenceResult
- UserFence DTOs (4): UserFencesResponse, SourceRef, EffectiveFenceDto, Counts
- Attendance DTOs (3): TodaySummaryResponse, PunchResponse, PunchCreateRequest
- Punch DTOs (2): PunchRequestViewDto, PunchRequestCreateDto

Changes Applied to Each DTO:
- Added Lombok annotations: @Getter, @Setter, @AllArgsConstructor, @NoArgsConstructor
- Removed 382 manual getter/setter methods
- Removed empty no-arg constructors (now generated by @NoArgsConstructor)
- Preserved all field annotations (@JsonProperty, @NotNull, @Valid, @Size, etc.)
- Preserved static factory methods (fromEntity in PolicyResponse, FenceResponse)
- Preserved custom business logic methods (increment methods in AssignmentSummary)
- Preserved inner classes with Lombok annotations (EventSummary in TodaySummaryResponse)

Benefits:
- Reduced boilerplate code by ~1000 lines
- Improved code maintainability
- Consistent DTO structure across the project
- All validation and serialization annotations retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)