### PR TITLE
refactor: Convert GET /getFence to POST with request body

### DIFF
--- a/backend/src/main/java/com/tse/core_application/dto/fence/FenceFilterRequest.java
+++ b/backend/src/main/java/com/tse/core_application/dto/fence/FenceFilterRequest.java
@@ -1,0 +1,22 @@
+package com.tse.core_application.dto.fence;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request body for filtering geo-fences")
+public class FenceFilterRequest {
+
+    @Schema(description = "Filter by status: active, inactive, or both", example = "both", defaultValue = "both")
+    private String status = "both";
+
+    @Schema(description = "Search by fence name (case-insensitive)", example = "Main Office")
+    private String q;
+
+    @Schema(description = "Filter by site code", example = "SITE001")
+    private String siteCode;
+}


### PR DESCRIPTION
- Changed endpoint from GET to POST to support request body
- Created FenceFilterRequest DTO to encapsulate filter parameters (status, q, siteCode)
- This allows for easier extension of filter fields in the future
- Frontend can now send filters in request body instead of query params

🤖 Generated with [Claude Code](https://claude.com/claude-code)